### PR TITLE
 chore: create CODE_OF_CONDUCT and README hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,7 +304,6 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+Kreuzberg is committed to a welcoming, respectful community for everyone regardless of
+background or experience level.
+
+## Expected Behaviour
+
+- Be respectful and constructive in all interactions.
+- Accept feedback graciously; give it thoughtfully.
+- Focus discussions on technical substance.
+- Assume good faith until evidence suggests otherwise.
+
+## Unacceptable Behaviour
+
+Personal attacks, sustained disruption, and discriminatory language are not tolerated.
+
+## Enforcement
+
+Report issues to **<conduct@kreuzberg.dev>**. All reports are reviewed confidentially.
+Maintainers may warn, temporarily restrict, or permanently remove contributors whose
+behaviour harms the community.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — issues, pull requests, discussions,
+Discord, and any other venue where contributors represent the project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
 - [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) — tree-sitter grammars and code-intelligence primitives.
-- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces all per-language bindings.
+- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces every per-language binding across the 5 polyglot repos.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -85,9 +85,18 @@
   <a href="https://docs.kreuzberg.dev/demo.html">
     <img height="22" src="https://img.shields.io/badge/Live%20Demo-Open-007ec6?logo=webassembly&logoColor=white" alt="Live Demo">
   </a>
+  <a href="https://github.com/kreuzberg-dev/kreuzberg/stargazers">
+    <img height="22" src="https://img.shields.io/github/stars/kreuzberg-dev/kreuzberg?style=social" alt="GitHub Stars">
+  </a>
 </div>
 
 Extract text, metadata, transcripts, and code intelligence from 96 file formats and 306 programming languages at native speeds without needing a GPU.
+
+<div align="center">
+
+**If Kreuzberg saves you time, please [⭐ star it on GitHub](https://github.com/kreuzberg-dev/kreuzberg/stargazers) — every star helps more developers find this project.**
+
+</div>
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@
 Extract text, metadata, transcripts, and code intelligence from 96 file formats and 306 programming languages at native speeds without needing a GPU.
 
 <div align="center">
-
-**If Kreuzberg saves you time, please [⭐ star it on GitHub](https://github.com/kreuzberg-dev/kreuzberg/stargazers) — every star helps more developers find this project.**
-
+  <a href="https://github.com/kreuzberg-dev/kreuzberg/stargazers">
+    <img width="1515" height="647" alt="stars" src="https://github.com/user-attachments/assets/acae69af-bbd4-44f0-b13a-b6269cdd4042" />
+  </a>
 </div>
 
 ## Key Features


### PR DESCRIPTION
add CODE_OF_CONDUCT.md (Contributor Covenant 2.1) and sync README: add GitHub stars badge to the social links row and update the alef ecosystem entry to canonical wording.