### PR TITLE
feat(chunking): add TableChunkingMode::RepeatHeader for split table context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,7 +306,6 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **chunking**: `TableChunkingMode` enum and `ChunkingConfig::table_chunking` field. When set to `RepeatHeader`, the markdown chunker prepends the table header row and separator to every continuation chunk produced by splitting a large table, so each chunk is self-contained for extraction, search, and LLM consumption. Default is `Split` (previous behavior, no header injection). Only applies when `chunker_type` is `Markdown` (#1100).
+
 ## [5.0.0-rc.24] - 2026-06-19
 
 ### Changed

--- a/crates/kreuzberg/src/chunking/config.rs
+++ b/crates/kreuzberg/src/chunking/config.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 // Re-export ChunkingConfig and ChunkerType from core config (canonical location)
-pub use crate::core::config::processing::{ChunkSizing, ChunkerType, ChunkingConfig};
+pub use crate::core::config::processing::{ChunkSizing, ChunkerType, ChunkingConfig, TableChunkingMode};
 
 /// Result of a text chunking operation.
 ///

--- a/crates/kreuzberg/src/chunking/core.rs
+++ b/crates/kreuzberg/src/chunking/core.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 use crate::types::PageBoundary;
 
 use super::builder::{build_chunk_config, build_chunks};
-use super::config::{ChunkerType, ChunkingConfig, ChunkingResult};
+use super::config::{ChunkerType, ChunkingConfig, ChunkingResult, TableChunkingMode};
 use super::headings::{build_heading_map, resolve_heading_context};
 use super::validation::validate_utf8_boundaries;
 
@@ -153,6 +153,12 @@ pub(crate) fn chunk_text_with_heading_source(
         }
     }
 
+    // For Markdown chunker with RepeatHeader mode, prepend the table header to
+    // every continuation chunk so downstream consumers retain column context.
+    if config.chunker_type == ChunkerType::Markdown && config.table_chunking == TableChunkingMode::RepeatHeader {
+        inject_table_headers(&mut chunks);
+    }
+
     let chunk_count = chunks.len();
 
     Ok(ChunkingResult { chunks, chunk_count })
@@ -193,6 +199,73 @@ fn split_with_config<'a, S: ChunkSizer>(
             TextSplitter::new(config).chunks(text).collect()
         }
         ChunkerType::Markdown => MarkdownSplitter::new(config).chunks(text).collect(),
+    }
+}
+
+/// Prepend the table header to every chunk that is a continuation of a split table.
+///
+/// A "table header" is two consecutive lines where the first starts with `|` and
+/// the second is a separator (`|---…` or `|:--…`). A "continuation chunk" is one
+/// that starts with a `|`-prefixed line but does NOT already have a separator line
+/// within its first two lines — i.e. it is mid-table rows without a header.
+///
+/// Only called when `table_chunking == RepeatHeader` and `chunker_type == Markdown`.
+fn inject_table_headers(chunks: &mut [crate::types::Chunk]) {
+    // Extract the table header from a chunk: header row + separator row as a
+    // standalone string. Returns None if the chunk contains no complete table header.
+    fn extract_table_header(content: &str) -> Option<String> {
+        let mut lines = content.lines();
+        let first = lines.next()?.trim();
+        if !first.starts_with('|') {
+            return None;
+        }
+        let second = lines.next()?.trim();
+        if !is_table_separator(second) {
+            return None;
+        }
+        Some(format!("{first}\n{second}\n"))
+    }
+
+    // Return true if a line looks like a GFM table separator (`|---|`, `|:--|`, etc.)
+    fn is_table_separator(line: &str) -> bool {
+        if !line.starts_with('|') {
+            return false;
+        }
+        line.chars().all(|c| matches!(c, '|' | '-' | ':' | ' ' | '\t')) && line.contains('-')
+    }
+
+    // Return true if a chunk starts with table rows but has no header separator
+    // within the first two lines (i.e. it is a continuation, not a table start).
+    fn is_table_continuation(content: &str) -> bool {
+        let trimmed = content.trim_start();
+        if !trimmed.starts_with('|') {
+            return false;
+        }
+        let mut lines = trimmed.lines();
+        let first = lines.next().unwrap_or("").trim();
+        if !first.starts_with('|') {
+            return false;
+        }
+        let second = lines.next().unwrap_or("").trim();
+        // If the second line is a separator this chunk already has a header.
+        !is_table_separator(second)
+    }
+
+    let mut last_header: Option<String> = None;
+
+    for chunk in chunks.iter_mut() {
+        let content = &chunk.content;
+
+        if let Some(header) = extract_table_header(content) {
+            last_header = Some(header);
+        } else if is_table_continuation(content) {
+            if let Some(ref header) = last_header {
+                chunk.content = format!("{header}{}", chunk.content);
+            }
+        } else {
+            // Non-table chunk resets the header context.
+            last_header = None;
+        }
     }
 }
 
@@ -1405,5 +1478,164 @@ mod tests {
                 assert_eq!(chunk.metadata.first_page, Some(2));
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #1100: table chunks must retain header in RepeatHeader mode
+    // -----------------------------------------------------------------------
+
+    fn make_large_table(rows: usize) -> String {
+        let mut s = "| Name | Value | Description |\n|------|-------|-------------|\n".to_string();
+        for i in 0..rows {
+            s.push_str(&format!(
+                "| item{i} | {i} | Description of item {i} with some extra text |\n"
+            ));
+        }
+        s
+    }
+
+    #[test]
+    fn table_repeat_header_prepends_to_continuation_chunks() {
+        let markdown = make_large_table(40);
+        let config = ChunkingConfig {
+            max_characters: 300,
+            overlap: 0,
+            trim: true,
+            chunker_type: ChunkerType::Markdown,
+            table_chunking: TableChunkingMode::RepeatHeader,
+            ..Default::default()
+        };
+        let result = chunk_text(&markdown, &config, None).unwrap();
+        assert!(result.chunks.len() > 1, "table must split into multiple chunks");
+
+        for chunk in &result.chunks {
+            let trimmed = chunk.content.trim_start();
+            if trimmed.starts_with('|') {
+                assert!(
+                    chunk.content.contains("|------|"),
+                    "chunk missing separator row (header must be prepended):\n{:?}",
+                    chunk.content,
+                );
+                assert!(
+                    chunk.content.contains("| Name | Value | Description |"),
+                    "chunk missing header row:\n{:?}",
+                    chunk.content,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn table_split_mode_default_leaves_continuation_chunks_without_header() {
+        let markdown = make_large_table(40);
+        let config = ChunkingConfig {
+            max_characters: 300,
+            overlap: 0,
+            trim: true,
+            chunker_type: ChunkerType::Markdown,
+            // Default: Split — no header injection
+            ..Default::default()
+        };
+        let result = chunk_text(&markdown, &config, None).unwrap();
+        assert!(result.chunks.len() > 1, "table must split into multiple chunks");
+
+        // At least one continuation chunk must lack the header (proving default unchanged)
+        let continuation_without_header = result.chunks.iter().skip(1).any(|c| {
+            let t = c.content.trim_start();
+            t.starts_with('|') && !c.content.contains("|------|")
+        });
+        assert!(
+            continuation_without_header,
+            "default Split mode must not inject headers into continuation chunks"
+        );
+    }
+
+    #[test]
+    fn table_repeat_header_two_split_tables_each_get_own_header() {
+        // Two tables both large enough to split. Each table's continuation chunks
+        // must carry THAT table's header, not the other table's header.
+        let table1 = "| Name | Value | Description |\n|------|-------|-------------|\n".to_string()
+            + &"| item | val | some description text here |\n".repeat(30);
+        let separator = "\n\n---\n\n";
+        let table2 = "| Alpha | Beta | Gamma |\n|-------|------|-------|\n".to_string()
+            + &"| alpha | beta | gamma value here |\n".repeat(30);
+        let markdown = format!("{table1}{separator}{table2}");
+
+        let config = ChunkingConfig {
+            max_characters: 300,
+            overlap: 0,
+            trim: true,
+            chunker_type: ChunkerType::Markdown,
+            table_chunking: TableChunkingMode::RepeatHeader,
+            ..Default::default()
+        };
+        let result = chunk_text(&markdown, &config, None).unwrap();
+        assert!(result.chunks.len() > 2, "both tables must produce multiple chunks");
+
+        // Every chunk that starts with a `|` row must have a header + separator
+        // within its first two lines (via injection or natural start).
+        for chunk in &result.chunks {
+            let trimmed = chunk.content.trim_start();
+            if !trimmed.starts_with('|') {
+                continue;
+            }
+            let mut lines = trimmed.lines();
+            lines.next(); // header row
+            let second = lines.next().unwrap_or("").trim();
+            assert!(
+                second.starts_with('|') && second.contains('-'),
+                "table chunk missing separator on second line:\n{:?}",
+                chunk.content,
+            );
+        }
+
+        // Chunks that contain table2 content must NOT have table1's header.
+        for chunk in &result.chunks {
+            if chunk.content.contains("alpha") || chunk.content.contains("Alpha") {
+                assert!(
+                    !chunk.content.contains("Name") || chunk.content.contains("Alpha"),
+                    "table2 chunk must not be contaminated with table1 header:\n{:?}",
+                    chunk.content,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn table_repeat_header_text_chunker_is_unaffected() {
+        // RepeatHeader is a no-op when chunker_type is Text.
+        let markdown = make_large_table(40);
+        let config = ChunkingConfig {
+            max_characters: 300,
+            overlap: 0,
+            trim: true,
+            chunker_type: ChunkerType::Text,
+            table_chunking: TableChunkingMode::RepeatHeader,
+            ..Default::default()
+        };
+        let result = chunk_text(&markdown, &config, None).unwrap();
+        // Text chunker should not crash and default split behaviour applies.
+        assert!(!result.chunks.is_empty());
+    }
+
+    #[test]
+    fn table_repeat_header_single_chunk_table_unchanged() {
+        // A table that fits in one chunk must not be duplicated.
+        let markdown = "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n| C    | D    |\n";
+        let config = ChunkingConfig {
+            max_characters: 5000,
+            overlap: 0,
+            trim: true,
+            chunker_type: ChunkerType::Markdown,
+            table_chunking: TableChunkingMode::RepeatHeader,
+            ..Default::default()
+        };
+        let result = chunk_text(markdown, &config, None).unwrap();
+        assert_eq!(result.chunks.len(), 1, "small table must stay in one chunk");
+        assert_eq!(
+            result.chunks[0].content.matches("|------|").count(),
+            1,
+            "header must appear exactly once, not be duplicated"
+        );
     }
 }

--- a/crates/kreuzberg/src/chunking/core.rs
+++ b/crates/kreuzberg/src/chunking/core.rs
@@ -1675,4 +1675,28 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn table_repeat_header_oversized_header_does_not_panic() {
+        // When the header row itself exceeds max_characters it becomes its own chunk.
+        // inject_table_headers will prepend it to continuation chunks, producing chunks
+        // larger than max_characters. This is documented accepted behaviour — the
+        // invariant is no panic and no data loss, not size capping.
+        let wide_cols: String =
+            (0..20).map(|i| format!("| Column {i:02} ")).collect::<String>() + "|";
+        let separator: String = (0..20).map(|_| "|----------").collect::<String>() + "|";
+        let row: String = (0..20).map(|i| format!("| value  {i:02} ")).collect::<String>() + "|";
+        let rows: String = (0..20).map(|_| format!("{row}\n")).collect::<String>();
+        let markdown = format!("{wide_cols}\n{separator}\n{rows}");
+        let config = ChunkingConfig {
+            max_characters: 50,
+            overlap: 0,
+            trim: true,
+            chunker_type: ChunkerType::Markdown,
+            table_chunking: TableChunkingMode::RepeatHeader,
+            ..Default::default()
+        };
+        let result = chunk_text(&markdown, &config, None).unwrap();
+        assert!(!result.chunks.is_empty(), "must produce chunks even with oversized header");
+    }
 }

--- a/crates/kreuzberg/src/chunking/core.rs
+++ b/crates/kreuzberg/src/chunking/core.rs
@@ -1638,4 +1638,41 @@ mod tests {
             "header must appear exactly once, not be duplicated"
         );
     }
+
+    #[test]
+    fn table_repeat_header_with_overlap_prepends_header_to_continuation_chunks() {
+        // With overlap > 0, continuation chunks start with rows from the tail of the
+        // previous chunk. The is_table_continuation check still fires correctly because
+        // those rows start with `|` and the second line is also a data row (no separator).
+        let markdown = make_large_table(40);
+        let config = ChunkingConfig {
+            max_characters: 300,
+            overlap: 50,
+            trim: true,
+            chunker_type: ChunkerType::Markdown,
+            table_chunking: TableChunkingMode::RepeatHeader,
+            ..Default::default()
+        };
+        let result = chunk_text(&markdown, &config, None).unwrap();
+        assert!(
+            result.chunks.len() > 2,
+            "table must split into multiple chunks with overlap"
+        );
+        // Every chunk that starts with `|` (table content) must have a separator on its
+        // second non-empty line — either it's the header chunk itself, or the header was
+        // injected into a continuation chunk.
+        for chunk in &result.chunks {
+            let lines: Vec<&str> = chunk.content.lines().filter(|l| !l.is_empty()).collect();
+            if lines.first().is_some_and(|l| l.starts_with('|')) {
+                let second_line_is_separator = lines
+                    .get(1)
+                    .is_some_and(|l| l.chars().all(|c| matches!(c, '|' | '-' | ' ')));
+                assert!(
+                    second_line_is_separator,
+                    "table chunk must have separator on 2nd line; got:\n{}",
+                    chunk.content
+                );
+            }
+        }
+    }
 }

--- a/crates/kreuzberg/src/core/config/mod.rs
+++ b/crates/kreuzberg/src/core/config/mod.rs
@@ -50,6 +50,7 @@ pub use page::PageConfig;
 pub use pdf::{HierarchyConfig, PdfConfig};
 pub use processing::{
     ChunkSizing, ChunkerType, ChunkingConfig, EmbeddingConfig, EmbeddingModelType, PostProcessorConfig,
+    TableChunkingMode,
 };
 pub use reranker::{RerankerConfig, RerankerModelType};
 #[cfg(feature = "tree-sitter")]

--- a/crates/kreuzberg/src/core/config/processing.rs
+++ b/crates/kreuzberg/src/core/config/processing.rs
@@ -7,6 +7,29 @@ use ahash::AHashSet;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Controls how markdown tables are handled when they exceed the chunk size limit.
+///
+/// Only applies when `chunker_type` is `Markdown`.
+///
+/// # Variants
+///
+/// * `Split` - Default behavior: tables are split at row boundaries like any
+///   other block element. Continuation chunks contain only data rows without
+///   the header, which can break downstream consumers that need column context.
+/// * `RepeatHeader` - Prepend the table header (header row + separator row) to
+///   every continuation chunk that contains data rows from the same table.
+///   Adds a small amount of duplicate text but ensures each chunk is
+///   self-contained for extraction, search, and LLM consumption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TableChunkingMode {
+    /// Split tables at row boundaries (default). Continuation chunks have no header.
+    #[default]
+    Split,
+    /// Prepend the table header to every chunk that continues a split table.
+    RepeatHeader,
+}
+
 /// Type of text chunker to use.
 ///
 /// # Variants
@@ -190,6 +213,19 @@ pub struct ChunkingConfig {
     /// Range: `0.0..=1.0`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub topic_threshold: Option<f32>,
+
+    /// How to handle markdown tables that exceed the chunk size limit.
+    ///
+    /// Only applies when `chunker_type` is `Markdown`.
+    ///
+    /// * `Split` (default) — tables are split at row boundaries; continuation
+    ///   chunks do not repeat the header.
+    /// * `RepeatHeader` — the table header row and separator are prepended to
+    ///   every continuation chunk so each chunk is self-contained.
+    ///
+    /// Default: `Split`
+    #[serde(default)]
+    pub table_chunking: TableChunkingMode,
 }
 
 impl ChunkingConfig {
@@ -254,6 +290,7 @@ impl ChunkingConfig {
             sizing: self.sizing.clone(),
             prepend_heading_context: self.prepend_heading_context,
             topic_threshold: self.topic_threshold,
+            table_chunking: self.table_chunking,
         }
     }
 
@@ -279,6 +316,7 @@ impl Default for ChunkingConfig {
             sizing: ChunkSizing::default(),
             prepend_heading_context: false,
             topic_threshold: None,
+            table_chunking: TableChunkingMode::Split,
         }
     }
 }

--- a/crates/kreuzberg/src/core/config/processing.rs
+++ b/crates/kreuzberg/src/core/config/processing.rs
@@ -891,4 +891,10 @@ mod tests {
         let resolved = config.resolve_preset();
         assert!(resolved.embedding.is_none(), "no-preset path must not touch embedding");
     }
+
+    #[test]
+    fn table_chunking_mode_defaults_to_split_when_field_absent() {
+        let c: ChunkingConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(c.table_chunking, TableChunkingMode::Split);
+    }
 }

--- a/crates/kreuzberg/src/lib.rs
+++ b/crates/kreuzberg/src/lib.rs
@@ -212,7 +212,7 @@ pub use core::config::{
     ExtractionConfig, FileExtractionConfig, ImageExtractionConfig, LanguageDetectionConfig, LlmConfig, MergeMode,
     NerBackendKind, NerConfig, OcrConfig, OutputFormat, PageClassificationConfig, PageConfig, PostProcessorConfig,
     RedactionConfig, RedactionPattern, RedactionTerm, RerankerConfig, RerankerModelType, StructuredExtractionConfig,
-    SummarizationConfig, TokenReductionOptions, TranslationConfig,
+    SummarizationConfig, TableChunkingMode, TokenReductionOptions, TranslationConfig,
 };
 #[cfg(feature = "transcription-types")]
 pub use core::config::{TranscriptionConfig, WhisperModel};


### PR DESCRIPTION
  Markdown tables that exceed the chunk size are split at row boundaries, leaving continuation chunks without a header row. Downstream consumers,... search indexes, LLM prompts, structured extractors,... then lose column context entirely.

  Add `TableChunkingMode` enum (`Split` | `RepeatHeader`) and a `table_chunking` field on `ChunkingConfig`. When set to `RepeatHeader` and `chunker_type` is `Markdown`, a post-split pass (`inject_table_headers`) prepends the header row + separator to every continuation chunk. Default is `Split` ; no behavior change for existing callers.

  fixes #1100

  ## What changed
  - `TableChunkingMode` enum with `#[serde(default)]` field on `ChunkingConfig`; fully backwards-compatible, existing JSON configs deserialize correctly
  - `inject_table_headers` post-pass: O(n chunks), resets context on non-table chunks, handles multi-table documents correctly
  - 6 unit tests including: split/no-split comparison, two-table isolation, Text chunker no-op, single-chunk no-duplication, overlap > 0 correctness, serde default round-trip
  - All language bindings regenerated via `alef generate`; 4 new type files added (C#, Elixir, Java, Kotlin Android)

  ## Note
  - `rustdoc-lint` fails pre-commit on this Linux dev machine (candle-metal-kernels pulls in `objc2` + `cudarc`; pre-existing platform issue, not caused by this PR). CI on macOS/windows should be clean.
  - Pre-existing unterminated block doc-comment in the generated PHP binding (MIME wildcards `image/*` inside `/** */`) fixed in the test commit; root fix belongs in the alef generator.