### PR TITLE
fix(pptx): preserve slide page numbers for untitled slides

### DIFF
--- a/crates/xberg/src/extraction/pptx/mod.rs
+++ b/crates/xberg/src/extraction/pptx/mod.rs
@@ -78,6 +78,17 @@ pub struct PptxExtractionOptions {
     pub inject_placeholders: bool,
 }
 
+/// Crate-internal PPTX extraction output.
+///
+/// `slide_contents` keeps the archive-derived slide number alongside each
+/// rendered slide. The public result remains unchanged, while the internal
+/// extractor can rebuild page-aware elements without embedding forgeable
+/// boundary markers in user-controlled text.
+pub(crate) struct PptxInternalExtraction {
+    pub(crate) result: PptxExtractionResult,
+    pub(crate) slide_contents: Vec<(u32, String)>,
+}
+
 impl Default for PptxExtractionOptions {
     fn default() -> Self {
         Self {
@@ -118,12 +129,13 @@ fn join_runs_with_spacing(runs: &[Run], extract: impl Fn(&Run) -> String) -> Str
 ///
 /// # Returns
 ///
-/// A `PptxExtractionResult` containing extracted content, metadata, and images.
-pub(crate) fn extract_pptx_from_path(
+/// The public extraction result plus archive-derived per-slide content used
+/// internally to assign trustworthy page metadata.
+pub(crate) fn extract_pptx_from_path_with_slide_contents(
     path: &str,
     options: &PptxExtractionOptions,
     warnings: &mut Vec<ProcessingWarning>,
-) -> Result<PptxExtractionResult> {
+) -> Result<PptxInternalExtraction> {
     let container = PptxContainer::open(path)?;
     extract_pptx_from_container(container, options, warnings)
 }
@@ -138,11 +150,20 @@ pub(crate) fn extract_pptx_from_path(
 /// # Returns
 ///
 /// A `PptxExtractionResult` containing extracted content, metadata, and images.
+#[cfg(test)]
 pub(crate) fn extract_pptx_from_bytes(
     data: &[u8],
     options: &PptxExtractionOptions,
     warnings: &mut Vec<ProcessingWarning>,
 ) -> Result<PptxExtractionResult> {
+    Ok(extract_pptx_from_bytes_with_slide_contents(data, options, warnings)?.result)
+}
+
+pub(crate) fn extract_pptx_from_bytes_with_slide_contents(
+    data: &[u8],
+    options: &PptxExtractionOptions,
+    warnings: &mut Vec<ProcessingWarning>,
+) -> Result<PptxInternalExtraction> {
     let container = PptxContainer::from_bytes(data)?;
     extract_pptx_from_container(container, options, warnings)
 }
@@ -151,7 +172,7 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
     mut container: PptxContainer<R>,
     options: &PptxExtractionOptions,
     warnings: &mut Vec<ProcessingWarning>,
-) -> Result<PptxExtractionResult> {
+) -> Result<PptxInternalExtraction> {
     let config = ParserConfig {
         extract_images: options.extract_images,
         plain: options.plain,
@@ -177,6 +198,7 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
 
     let mut total_image_count = 0;
     let mut total_table_count = 0;
+    let mut slide_contents = Vec::with_capacity(slide_count);
     let mut extracted_images = Vec::new();
     let mut collected_hyperlinks: Vec<(String, Option<String>)> = Vec::new();
     let mut doc_builder = if include_structure {
@@ -194,16 +216,25 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
         };
 
         let slide_content = slide.to_markdown(&config);
-        // Preserve the archive-derived slide number for the internal document
-        // builder. The marker is consumed before final rendering and is kept out
-        // of `slide_content`, so it does not leak into per-slide output.
-        content_builder.add_slide_header(slide.slide_number);
         content_builder.add_text(&slide_content);
 
         let slide_notes = notes.get(&slide.slide_number).cloned();
         if let Some(ref note_text) = slide_notes {
             content_builder.add_notes(note_text);
         }
+
+        let mut internal_slide_content = slide_content.clone();
+        if let Some(ref note_text) = slide_notes
+            && !note_text.trim().is_empty()
+        {
+            if options.plain {
+                internal_slide_content.push_str("\n\nNotes:\n");
+            } else {
+                internal_slide_content.push_str("\n\n### Notes:\n");
+            }
+            internal_slide_content.push_str(note_text);
+        }
+        slide_contents.push((slide.slide_number, internal_slide_content));
 
         let slide_section = section_names.get(&slide.slide_number).cloned();
 
@@ -325,19 +356,22 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
 
     let document = doc_builder.map(|b| b.build()).filter(|d| !d.is_empty());
 
-    Ok(PptxExtractionResult {
-        content,
-        metadata,
-        slide_count,
-        image_count: total_image_count,
-        table_count: total_table_count,
-        images: extracted_images,
-        page_structure,
-        page_contents,
-        document,
-        hyperlinks: collected_hyperlinks,
-        office_metadata,
-        revisions,
+    Ok(PptxInternalExtraction {
+        result: PptxExtractionResult {
+            content,
+            metadata,
+            slide_count,
+            image_count: total_image_count,
+            table_count: total_table_count,
+            images: extracted_images,
+            page_structure,
+            page_contents,
+            document,
+            hyperlinks: collected_hyperlinks,
+            office_metadata,
+            revisions,
+        },
+        slide_contents,
     })
 }
 
@@ -866,7 +900,7 @@ pub(crate) mod tests {
     #[test]
     fn test_extract_pptx_from_bytes_multiple_slides() {
         let pptx_bytes = create_test_pptx_bytes(vec!["Slide 1", "Slide 2", "Slide 3"]);
-        let result = extract_pptx_from_bytes(
+        let internal = extract_pptx_from_bytes_with_slide_contents(
             &pptx_bytes,
             &PptxExtractionOptions {
                 extract_images: false,
@@ -875,19 +909,21 @@ pub(crate) mod tests {
             &mut Vec::new(),
         )
         .unwrap();
+        let result = internal.result;
 
         assert_eq!(result.slide_count, 3);
         assert!(result.content.contains("Slide 1"));
         assert!(result.content.contains("Slide 2"));
         assert!(result.content.contains("Slide 3"));
-        for slide_number in 1..=3 {
-            assert!(
-                result
-                    .content
-                    .contains(&format!("<!-- Slide number: {slide_number} -->")),
-                "combined content should preserve the boundary for slide {slide_number}"
-            );
-        }
+        assert!(!result.content.contains("<!-- Slide number:"));
+        assert_eq!(
+            internal
+                .slide_contents
+                .iter()
+                .map(|(number, _)| *number)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
     }
 
     #[test]
@@ -1706,7 +1742,7 @@ pub(crate) mod tests {
     /// Build a minimal single-slide PPTX with caller-supplied slide XML,
     /// optional slide relationships XML, and optional extra ZIP parts (used
     /// for chart/SmartArt data parts and referenced media).
-    fn build_single_slide_pptx(
+    pub(crate) fn build_single_slide_pptx(
         slide_xml: &str,
         slide_rels_xml: Option<&str>,
         extra_parts: &[(&str, &[u8])],

--- a/crates/xberg/src/extraction/pptx/mod.rs
+++ b/crates/xberg/src/extraction/pptx/mod.rs
@@ -194,6 +194,10 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
         };
 
         let slide_content = slide.to_markdown(&config);
+        // Preserve the archive-derived slide number for the internal document
+        // builder. The marker is consumed before final rendering and is kept out
+        // of `slide_content`, so it does not leak into per-slide output.
+        content_builder.add_slide_header(slide.slide_number);
         content_builder.add_text(&slide_content);
 
         let slide_notes = notes.get(&slide.slide_number).cloned();
@@ -876,6 +880,14 @@ pub(crate) mod tests {
         assert!(result.content.contains("Slide 1"));
         assert!(result.content.contains("Slide 2"));
         assert!(result.content.contains("Slide 3"));
+        for slide_number in 1..=3 {
+            assert!(
+                result
+                    .content
+                    .contains(&format!("<!-- Slide number: {slide_number} -->")),
+                "combined content should preserve the boundary for slide {slide_number}"
+            );
+        }
     }
 
     #[test]

--- a/crates/xberg/src/extractors/pptx.rs
+++ b/crates/xberg/src/extractors/pptx.rs
@@ -33,8 +33,8 @@ impl PptxExtractor {
 impl PptxExtractor {
     /// Build an `InternalDocument` from PPTX extracted text.
     ///
-    /// Splits content by double-newlines into slide-like blocks. Each block
-    /// becomes a slide element with its content as paragraphs.
+    /// Splits content by double-newlines and uses internal slide markers to
+    /// retain the archive-derived slide number while rebuilding elements.
     ///
     /// Note: For richer structure, the builder should be integrated into
     /// `crate::extraction::pptx` alongside the existing `DocumentStructure` building.
@@ -65,6 +65,7 @@ impl PptxExtractor {
         let mut builder = InternalDocumentBuilder::new("pptx");
         let mut slide_num: u32 = 0;
         let mut in_notes = false;
+        let has_slide_markers = content.contains("<!-- Slide number: ");
 
         let blocks: Vec<&str> = content.split("\n\n").collect();
 
@@ -75,6 +76,17 @@ impl PptxExtractor {
                 continue;
             }
 
+            if let Some(marker) = trimmed
+                .strip_prefix("<!-- Slide number: ")
+                .and_then(|value| value.strip_suffix(" -->"))
+                && let Ok(number) = marker.parse::<u32>()
+                && (1..=slide_count).contains(&number)
+            {
+                slide_num = number;
+                in_notes = false;
+                continue;
+            }
+
             if trimmed.starts_with("### Notes:") || trimmed == "Notes:" {
                 in_notes = true;
                 continue;
@@ -82,7 +94,9 @@ impl PptxExtractor {
 
             if let Some(title_text) = trimmed.strip_prefix("# ") {
                 in_notes = false;
-                slide_num += 1;
+                if !has_slide_markers {
+                    slide_num += 1;
+                }
                 let title = title_text.trim();
                 if !title.is_empty() {
                     budget.account_text(title.len())?;
@@ -458,6 +472,39 @@ mod tests {
         assert!(mime_types.contains(&"application/vnd.openxmlformats-officedocument.presentationml.presentation"));
     }
 
+    #[test]
+    fn test_internal_slide_markers_set_table_and_list_page_numbers() {
+        use crate::types::internal::ElementKind;
+
+        let content = concat!(
+            "<!-- Slide number: 1 -->\n\n",
+            "# Titled slide\n\n",
+            "Introduction\n\n",
+            "<!-- Slide number: 2 -->\n\n",
+            "This untitled slide has a paragraph long enough not to be inferred as a title. ",
+            "It deliberately contains more than one hundred characters in total.\n\n",
+            "<!-- Slide number: 3 -->\n\n",
+            "| Name | Value |\n",
+            "| --- | --- |\n",
+            "| answer | 42 |\n\n",
+            "- final item",
+        );
+        let mut budget = SecurityBudget::with_defaults();
+
+        let document = PptxExtractor::build_internal_document(content, 3, &mut budget)
+            .expect("internal PPTX document should build");
+
+        assert_eq!(document.tables.len(), 1);
+        assert_eq!(document.tables[0].page_number, 3);
+
+        let list_item = document
+            .elements
+            .iter()
+            .find(|element| matches!(element.kind, ElementKind::ListItem { .. }))
+            .expect("list item should be present");
+        assert_eq!(list_item.page, Some(3));
+    }
+
     /// Full round-trip through PptxExtractor::extract_bytes → derive_extraction_result →
     /// ExtractedDocument.pages, asserting that speaker_notes and section_name are present.
     #[tokio::test]
@@ -487,6 +534,10 @@ mod tests {
             .expect("extraction failed");
         let result = derive_extraction_result(internal_doc, true, crate::core::config::OutputFormat::Plain);
 
+        assert!(
+            !result.content.contains("<!-- Slide number:"),
+            "internal slide markers must not leak into rendered output"
+        );
         let pages = result.pages.as_ref().expect("pages should be populated");
         assert_eq!(pages.len(), 3);
 

--- a/crates/xberg/src/extractors/pptx.rs
+++ b/crates/xberg/src/extractors/pptx.rs
@@ -33,11 +33,9 @@ impl PptxExtractor {
 impl PptxExtractor {
     /// Build an `InternalDocument` from PPTX extracted text.
     ///
-    /// Splits content by double-newlines and uses internal slide markers to
-    /// retain the archive-derived slide number while rebuilding elements.
+    /// Parses each archive-derived slide independently so page metadata never
+    /// depends on headings or marker-like user text.
     ///
-    /// Note: For richer structure, the builder should be integrated into
-    /// `crate::extraction::pptx` alongside the existing `DocumentStructure` building.
     /// Try to strip an ordered-list prefix like `1. `, `2. `, `10. ` from a line.
     /// Returns the remaining text after the prefix, or `None` if the line does not
     /// start with a `<digits>. ` pattern.
@@ -58,114 +56,103 @@ impl PptxExtractor {
     }
 
     fn build_internal_document(
-        content: &str,
+        slide_contents: &[(u32, String)],
         slide_count: u32,
         budget: &mut SecurityBudget,
     ) -> Result<InternalDocument> {
         let mut builder = InternalDocumentBuilder::new("pptx");
-        let mut slide_num: u32 = 0;
-        let mut in_notes = false;
-        let has_slide_markers = content.contains("<!-- Slide number: ");
+        let mut saw_title = false;
 
-        let blocks: Vec<&str> = content.split("\n\n").collect();
+        for (slide_num, content) in slide_contents {
+            let mut in_notes = false;
 
-        for block in &blocks {
-            budget.step()?;
-            let trimmed = block.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-
-            if let Some(marker) = trimmed
-                .strip_prefix("<!-- Slide number: ")
-                .and_then(|value| value.strip_suffix(" -->"))
-                && let Ok(number) = marker.parse::<u32>()
-                && (1..=slide_count).contains(&number)
-            {
-                slide_num = number;
-                in_notes = false;
-                continue;
-            }
-
-            if trimmed.starts_with("### Notes:") || trimmed == "Notes:" {
-                in_notes = true;
-                continue;
-            }
-
-            if let Some(title_text) = trimmed.strip_prefix("# ") {
-                in_notes = false;
-                if !has_slide_markers {
-                    slide_num += 1;
+            for block in content.split("\n\n") {
+                budget.step()?;
+                let trimmed = block.trim();
+                if trimmed.is_empty() {
+                    continue;
                 }
-                let title = title_text.trim();
-                if !title.is_empty() {
-                    budget.account_text(title.len())?;
-                    builder.push_heading(2, title, None, None);
+
+                if trimmed.starts_with("### Notes:") || trimmed == "Notes:" {
+                    in_notes = true;
+                    continue;
                 }
-                continue;
-            }
 
-            if in_notes {
-                in_notes = false;
-            }
-
-            if trimmed.starts_with('|') {
-                let cells = Self::parse_markdown_table(trimmed);
-                if !cells.is_empty() {
-                    builder.push_table_from_cells(&cells, Some(slide_num), None);
-                }
-                continue;
-            }
-
-            let mut in_list: Option<bool> = None;
-
-            for line in trimmed.lines() {
-                let lt = line.trim();
-                if lt.is_empty() {
-                    if in_list.is_some() {
-                        builder.end_list();
-                        in_list = None;
+                if let Some(title_text) = trimmed.strip_prefix("# ") {
+                    in_notes = false;
+                    saw_title = true;
+                    let title = title_text.trim();
+                    if !title.is_empty() {
+                        budget.account_text(title.len())?;
+                        builder.push_heading(2, title, Some(*slide_num), None);
                     }
                     continue;
                 }
 
-                let list_match = if let Some(item_text) = lt.strip_prefix("- ") {
-                    Some((false, item_text))
-                } else {
-                    Self::strip_ordered_prefix(lt).map(|item_text| (true, item_text))
-                };
-
-                if let Some((ordered, item_text)) = list_match {
-                    match in_list {
-                        Some(prev_ordered) if prev_ordered != ordered => {
-                            builder.end_list();
-                            builder.push_list(ordered);
-                            in_list = Some(ordered);
-                        }
-                        None => {
-                            builder.push_list(ordered);
-                            in_list = Some(ordered);
-                        }
-                        _ => {}
-                    }
-                    budget.account_text(item_text.len())?;
-                    builder.push_list_item(item_text, ordered, vec![], Some(slide_num), None);
-                } else {
-                    if in_list.is_some() {
-                        builder.end_list();
-                        in_list = None;
-                    }
-                    budget.account_text(lt.len())?;
-                    builder.push_paragraph(lt, vec![], None, None);
+                if in_notes {
+                    in_notes = false;
                 }
-            }
 
-            if in_list.is_some() {
-                builder.end_list();
+                if trimmed.starts_with('|') {
+                    let cells = Self::parse_markdown_table(trimmed);
+                    if !cells.is_empty() {
+                        builder.push_table_from_cells(&cells, Some(*slide_num), None);
+                    }
+                    continue;
+                }
+
+                let mut in_list: Option<bool> = None;
+
+                for line in trimmed.lines() {
+                    let lt = line.trim();
+                    if lt.is_empty() {
+                        if in_list.is_some() {
+                            builder.end_list();
+                            in_list = None;
+                        }
+                        continue;
+                    }
+
+                    let list_match = if let Some(item_text) = lt.strip_prefix("- ") {
+                        Some((false, item_text))
+                    } else {
+                        Self::strip_ordered_prefix(lt).map(|item_text| (true, item_text))
+                    };
+
+                    if let Some((ordered, item_text)) = list_match {
+                        match in_list {
+                            Some(prev_ordered) if prev_ordered != ordered => {
+                                builder.end_list();
+                                builder.push_list(ordered);
+                                in_list = Some(ordered);
+                            }
+                            None => {
+                                builder.push_list(ordered);
+                                in_list = Some(ordered);
+                            }
+                            _ => {}
+                        }
+                        budget.account_text(item_text.len())?;
+                        builder.push_list_item(item_text, ordered, vec![], Some(*slide_num), None);
+                    } else {
+                        if in_list.is_some() {
+                            builder.end_list();
+                            in_list = None;
+                        }
+                        budget.account_text(lt.len())?;
+                        builder.push_paragraph(lt, vec![], Some(*slide_num), None);
+                    }
+                }
+
+                if in_list.is_some() {
+                    builder.end_list();
+                }
             }
         }
 
-        if slide_num == 0 && slide_count > 0 {
+        // Preserve the legacy all-untitled output shape: it contains one Slide
+        // sentinel, while titled decks do not gain new thematic-break/JSON nodes.
+        if !saw_title && slide_count > 0 {
             builder.push_slide(1, None, Some(1));
         }
 
@@ -204,6 +191,7 @@ impl PptxExtractor {
     /// hostile-input limits on the extracted content.
     fn build_document_from_result(
         pptx_result: crate::types::PptxExtractionResult,
+        slide_contents: &[(u32, String)],
         mime_type: &str,
         extract_images: bool,
         budget: &mut SecurityBudget,
@@ -247,7 +235,7 @@ impl PptxExtractor {
             }
         }
 
-        let mut doc = Self::build_internal_document(&pptx_result.content, pptx_result.slide_count as u32, budget)?;
+        let mut doc = Self::build_internal_document(slide_contents, pptx_result.slide_count as u32, budget)?;
         doc.mime_type = mime_type.to_string();
 
         let mut metadata = Metadata {
@@ -324,7 +312,7 @@ impl InternalDocumentExtractor for PptxExtractor {
 
         let mut pptx_warnings: Vec<crate::types::ProcessingWarning> = Vec::new();
 
-        let pptx_result = {
+        let pptx_internal = {
             #[cfg(feature = "tokio-runtime")]
             {
                 if crate::core::batch_mode::is_batch_mode() {
@@ -343,8 +331,11 @@ impl InternalDocumentExtractor for PptxExtractor {
                     let (result, warnings) = tokio::task::spawn_blocking(move || {
                         let _guard = span.entered();
                         let mut warnings = Vec::new();
-                        let result =
-                            crate::extraction::pptx::extract_pptx_from_bytes(&content_owned, &options, &mut warnings);
+                        let result = crate::extraction::pptx::extract_pptx_from_bytes_with_slide_contents(
+                            &content_owned,
+                            &options,
+                            &mut warnings,
+                        );
                         (result, warnings)
                     })
                     .await
@@ -359,7 +350,11 @@ impl InternalDocumentExtractor for PptxExtractor {
                         include_structure: false,
                         inject_placeholders,
                     };
-                    crate::extraction::pptx::extract_pptx_from_bytes(content, &options, &mut pptx_warnings)?
+                    crate::extraction::pptx::extract_pptx_from_bytes_with_slide_contents(
+                        content,
+                        &options,
+                        &mut pptx_warnings,
+                    )?
                 }
             }
 
@@ -372,12 +367,22 @@ impl InternalDocumentExtractor for PptxExtractor {
                     include_structure: false,
                     inject_placeholders,
                 };
-                crate::extraction::pptx::extract_pptx_from_bytes(content, &options, &mut pptx_warnings)?
+                crate::extraction::pptx::extract_pptx_from_bytes_with_slide_contents(
+                    content,
+                    &options,
+                    &mut pptx_warnings,
+                )?
             }
         };
 
         let mut budget = SecurityBudget::from_config(config);
-        let mut doc = Self::build_document_from_result(pptx_result, mime_type, extract_images, &mut budget)?;
+        let mut doc = Self::build_document_from_result(
+            pptx_internal.result,
+            &pptx_internal.slide_contents,
+            mime_type,
+            extract_images,
+            &mut budget,
+        )?;
         doc.processing_warnings.extend(pptx_warnings);
 
         if config.max_archive_depth > 0 {
@@ -429,10 +434,20 @@ impl InternalDocumentExtractor for PptxExtractor {
             inject_placeholders,
         };
         let mut pptx_warnings: Vec<crate::types::ProcessingWarning> = Vec::new();
-        let pptx_result = crate::extraction::pptx::extract_pptx_from_path(path_str, &options, &mut pptx_warnings)?;
+        let pptx_internal = crate::extraction::pptx::extract_pptx_from_path_with_slide_contents(
+            path_str,
+            &options,
+            &mut pptx_warnings,
+        )?;
 
         let mut budget = SecurityBudget::from_config(config);
-        let mut doc = Self::build_document_from_result(pptx_result, mime_type, extract_images, &mut budget)?;
+        let mut doc = Self::build_document_from_result(
+            pptx_internal.result,
+            &pptx_internal.slide_contents,
+            mime_type,
+            extract_images,
+            &mut budget,
+        )?;
         doc.processing_warnings.extend(pptx_warnings);
         Ok(doc)
     }
@@ -473,25 +488,33 @@ mod tests {
     }
 
     #[test]
-    fn test_internal_slide_markers_set_table_and_list_page_numbers() {
+    fn test_archive_slide_contents_set_table_list_heading_and_paragraph_pages() {
         use crate::types::internal::ElementKind;
 
-        let content = concat!(
-            "<!-- Slide number: 1 -->\n\n",
-            "# Titled slide\n\n",
-            "Introduction\n\n",
-            "<!-- Slide number: 2 -->\n\n",
-            "This untitled slide has a paragraph long enough not to be inferred as a title. ",
-            "It deliberately contains more than one hundred characters in total.\n\n",
-            "<!-- Slide number: 3 -->\n\n",
-            "| Name | Value |\n",
-            "| --- | --- |\n",
-            "| answer | 42 |\n\n",
-            "- final item",
-        );
+        let slide_contents = vec![
+            (1, "# Titled slide\n\nIntroduction".to_string()),
+            (
+                2,
+                concat!(
+                    "This untitled slide has a paragraph long enough not to be inferred as a title. ",
+                    "It deliberately contains more than one hundred characters in total."
+                )
+                .to_string(),
+            ),
+            (
+                3,
+                concat!(
+                    "| Name | Value |\n",
+                    "| --- | --- |\n",
+                    "| answer | 42 |\n\n",
+                    "- final item"
+                )
+                .to_string(),
+            ),
+        ];
         let mut budget = SecurityBudget::with_defaults();
 
-        let document = PptxExtractor::build_internal_document(content, 3, &mut budget)
+        let document = PptxExtractor::build_internal_document(&slide_contents, 3, &mut budget)
             .expect("internal PPTX document should build");
 
         assert_eq!(document.tables.len(), 1);
@@ -503,6 +526,99 @@ mod tests {
             .find(|element| matches!(element.kind, ElementKind::ListItem { .. }))
             .expect("list item should be present");
         assert_eq!(list_item.page, Some(3));
+
+        let heading = document
+            .elements
+            .iter()
+            .find(|element| matches!(element.kind, ElementKind::Heading { .. }))
+            .expect("heading should be present");
+        assert_eq!(heading.page, Some(1));
+
+        let second_slide_paragraph = document
+            .elements
+            .iter()
+            .find(|element| element.text.starts_with("This untitled slide"))
+            .expect("second-slide paragraph should be present");
+        assert_eq!(second_slide_paragraph.page, Some(2));
+    }
+
+    #[test]
+    fn test_marker_like_slide_text_cannot_change_later_page_numbers() {
+        let slide_contents = vec![
+            (1, "First slide".to_string()),
+            (
+                2,
+                "<!-- Slide number: 99 -->\n\n| Name | Value |\n| --- | --- |\n| answer | 42 |".to_string(),
+            ),
+        ];
+        let mut budget = SecurityBudget::with_defaults();
+
+        let document = PptxExtractor::build_internal_document(&slide_contents, 2, &mut budget)
+            .expect("marker-like user text should remain ordinary slide content");
+
+        assert_eq!(document.tables.len(), 1);
+        assert_eq!(document.tables[0].page_number, 2);
+        assert!(document.elements.iter().any(|element| {
+            matches!(element.kind, crate::types::internal::ElementKind::Paragraph)
+                && element.text == "<!-- Slide number: 99 -->"
+                && element.page == Some(2)
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_untitled_slide_with_table_gets_archive_derived_page_numbers() {
+        use crate::plugins::InternalDocumentExtractor;
+        use crate::types::internal::ElementKind;
+
+        let slide_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+    <p:cSld><p:spTree>
+        <p:sp><p:txBody><a:p><a:r><a:t>This untitled slide contains a deliberately long paragraph so the extractor cannot mistake it for a title while assigning page metadata.</a:t></a:r></a:p></p:txBody></p:sp>
+        <p:graphicFrame>
+            <a:graphic>
+                <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+                    <a:tbl>
+                        <a:tr>
+                            <a:tc><a:txBody><a:p><a:r><a:t>Name</a:t></a:r></a:p></a:txBody></a:tc>
+                            <a:tc><a:txBody><a:p><a:r><a:t>Value</a:t></a:r></a:p></a:txBody></a:tc>
+                        </a:tr>
+                        <a:tr>
+                            <a:tc><a:txBody><a:p><a:r><a:t>answer</a:t></a:r></a:p></a:txBody></a:tc>
+                            <a:tc><a:txBody><a:p><a:r><a:t>42</a:t></a:r></a:p></a:txBody></a:tc>
+                        </a:tr>
+                    </a:tbl>
+                </a:graphicData>
+            </a:graphic>
+        </p:graphicFrame>
+    </p:spTree></p:cSld>
+</p:sld>"#;
+        let pptx = crate::extraction::pptx::tests::build_single_slide_pptx(slide_xml, None, &[]);
+        let extractor = PptxExtractor::new();
+        let config = ExtractionConfig {
+            output_format: crate::core::config::OutputFormat::Markdown,
+            ..Default::default()
+        };
+        let mime = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+
+        let document = extractor
+            .extract_content(&pptx, mime, &config)
+            .await
+            .expect("real PPTX extraction should succeed");
+
+        assert_eq!(document.tables.len(), 1);
+        assert_eq!(document.tables[0].page_number, 1);
+        assert!(document.elements.iter().any(|element| {
+            matches!(element.kind, ElementKind::Paragraph)
+                && element.text.starts_with("This untitled slide")
+                && element.page == Some(1)
+        }));
+        assert!(
+            document
+                .elements
+                .iter()
+                .any(|element| { matches!(element.kind, ElementKind::Slide { number: 1 }) && element.page == Some(1) })
+        );
     }
 
     /// Full round-trip through PptxExtractor::extract_bytes → derive_extraction_result →


### PR DESCRIPTION
## Related

Fixes #1412.

## Description

- Carry each archive-derived slide number alongside its rendered content in a crate-internal `PptxInternalExtraction` value instead of embedding a forgeable marker in user-controlled Markdown.
- Parse each slide independently when rebuilding the internal document, so tables, lists, headings, and paragraphs receive the archive slide number.
- Preserve the legacy all-untitled `ElementKind::Slide` sentinel while avoiding new slide nodes for titled decks.
- Keep combined content and page-boundary offsets free of synthetic slide comments.

Tables and list items after untitled slides now retain their actual slide number. Marker-like text inside a deck remains ordinary content and cannot restamp later elements.

## Validation

- `cargo test -p xberg --features office --lib 'pptx::tests::'` — 40 passed
- `XBERG_SKIP_TEST_DOCUMENTS=1 cargo test -p xberg --features office --lib` — 2,317 passed
- `cargo clippy -p xberg --features office --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Real-PPTX regression fixture: an untitled slide with a long paragraph and table receives page 1 for both elements and retains the legacy slide sentinel

The corpus skip is needed only because this shallow checkout does not initialize the `test_documents` submodule.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable