### PR TITLE
feat(vlm): decouple request concurrency from CPU threads

### DIFF
--- a/crates/xberg/src/core/config/concurrency.rs
+++ b/crates/xberg/src/core/config/concurrency.rs
@@ -183,6 +183,51 @@ pub(crate) fn resolve_thread_budget(config: Option<&ConcurrencyConfig>) -> usize
     resolve_thread_budget_inner(config, num_cpus::get(), cgroup_cpu_quota_cores())
 }
 
+/// Resolve the asynchronous request limit for a single LLM-backed feature.
+///
+/// An explicit per-LLM limit takes precedence over the general extraction
+/// thread budget. This keeps remote request fan-out independently tunable while
+/// preserving the historical behavior for configurations that do not opt in.
+#[cfg(feature = "captioning")]
+pub(crate) fn resolve_llm_concurrency(
+    llm_config: &crate::core::config::LlmConfig,
+    concurrency: Option<&ConcurrencyConfig>,
+) -> usize {
+    llm_config
+        .max_concurrency
+        .unwrap_or_else(|| resolve_thread_budget(concurrency))
+        .max(1)
+}
+
+/// Resolve the request limit for OCR work that can reach a VLM.
+///
+/// Explicit OCR pipelines own their stage configuration, so only VLM stages in
+/// that pipeline participate. Otherwise the top-level VLM configuration is
+/// used when the selected backend or fallback policy can issue VLM requests.
+#[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+pub(crate) fn resolve_ocr_concurrency(
+    ocr_config: &crate::core::config::OcrConfig,
+    concurrency: Option<&ConcurrencyConfig>,
+) -> usize {
+    let configured_limit = if let Some(pipeline) = ocr_config.pipeline.as_ref() {
+        pipeline
+            .stages
+            .iter()
+            .filter(|stage| stage.backend == "vlm")
+            .filter_map(|stage| stage.vlm_config.as_ref()?.max_concurrency)
+            .min()
+    } else if ocr_config.backend == "vlm" || ocr_config.vlm_fallback != crate::core::config::VlmFallbackPolicy::Disabled
+    {
+        ocr_config.vlm_config.as_ref().and_then(|config| config.max_concurrency)
+    } else {
+        None
+    };
+
+    configured_limit
+        .unwrap_or_else(|| resolve_thread_budget(concurrency))
+        .max(1)
+}
+
 /// Pure core of [`resolve_thread_budget`], parameterized on the host CPU
 /// count and any detected cgroup quota so tests can exercise every branch
 /// deterministically regardless of the machine actually running the tests.
@@ -401,6 +446,53 @@ mod tests {
     use tracing_subscriber::{EnvFilter, Layer};
 
     use super::*;
+
+    #[cfg(feature = "captioning")]
+    #[test]
+    fn llm_concurrency_overrides_general_thread_budget() {
+        let llm = crate::core::config::LlmConfig {
+            max_concurrency: Some(3),
+            ..Default::default()
+        };
+        let general = ConcurrencyConfig { max_threads: Some(12) };
+
+        assert_eq!(resolve_llm_concurrency(&llm, Some(&general)), 3);
+    }
+
+    #[cfg(feature = "captioning")]
+    #[test]
+    fn llm_concurrency_falls_back_to_general_thread_budget() {
+        let llm = crate::core::config::LlmConfig::default();
+        let general = ConcurrencyConfig { max_threads: Some(5) };
+
+        assert_eq!(resolve_llm_concurrency(&llm, Some(&general)), 5);
+    }
+
+    #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+    #[test]
+    fn ocr_concurrency_uses_explicit_vlm_pipeline_stage_limit() {
+        let ocr = crate::core::config::OcrConfig {
+            pipeline: Some(crate::core::config::OcrPipelineConfig {
+                stages: vec![crate::core::config::OcrPipelineStage {
+                    backend: "vlm".to_string(),
+                    priority: 100,
+                    language: None,
+                    tesseract_config: None,
+                    paddle_ocr_config: None,
+                    vlm_config: Some(crate::core::config::LlmConfig {
+                        max_concurrency: Some(2),
+                        ..Default::default()
+                    }),
+                    backend_options: None,
+                }],
+                quality_thresholds: Default::default(),
+            }),
+            ..Default::default()
+        };
+        let general = ConcurrencyConfig { max_threads: Some(8) };
+
+        assert_eq!(resolve_ocr_concurrency(&ocr, Some(&general)), 2);
+    }
 
     /// A tracing `Layer` that records the level of every emitted event.
     #[derive(Clone, Default)]

--- a/crates/xberg/src/core/config/llm.rs
+++ b/crates/xberg/src/core/config/llm.rs
@@ -286,6 +286,22 @@ pub struct LlmConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "alef-meta", alef(since = "1.1.0"))]
     pub credential_provider: Option<Box<CredentialProviderConfig>>,
+
+    /// Maximum number of in-flight VLM requests spawned by one extraction operation.
+    ///
+    /// VLM OCR and image captioning use this value to bound their asynchronous
+    /// request fan-out independently of [`super::ConcurrencyConfig::max_threads`].
+    /// Concurrent document extractions each receive their own allowance; combine
+    /// this with [`super::ExtractionConfig::max_concurrent_extractions`] or a
+    /// deployment-level worker limit when aggregate provider concurrency must also
+    /// be bounded. When `None`, those features retain the existing behavior and use
+    /// the extraction thread budget. Values below 1 are clamped to 1.
+    ///
+    /// This field is intentionally last to preserve positional constructor
+    /// compatibility in generated language bindings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "1.2.0"))]
+    pub max_concurrency: Option<usize>,
 }
 
 impl LlmConfig {
@@ -602,6 +618,7 @@ impl std::fmt::Debug for LlmConfig {
             .field("health_check_secs", &self.health_check_secs)
             .field("bedrock", &self.bedrock)
             .field("credential_provider", &self.credential_provider)
+            .field("max_concurrency", &self.max_concurrency)
             .finish()
     }
 }
@@ -743,6 +760,7 @@ mod tests {
         assert!(cfg.base_url.is_none());
         assert!(cfg.timeout_secs.is_none());
         assert!(cfg.max_retries.is_none());
+        assert!(cfg.max_concurrency.is_none());
         assert!(cfg.temperature.is_none());
         assert!(cfg.max_tokens.is_none());
         assert!(cfg.top_p.is_none());
@@ -779,6 +797,7 @@ mod tests {
         assert!(cfg.base_url.is_none());
         assert!(cfg.timeout_secs.is_none());
         assert!(cfg.max_retries.is_none());
+        assert!(cfg.max_concurrency.is_none());
         assert!(cfg.temperature.is_none());
         assert!(cfg.max_tokens.is_none());
         assert!(cfg.top_p.is_none());
@@ -820,6 +839,22 @@ load_env = true
         let headers = cfg.headers.as_ref().expect("headers present");
         assert_eq!(headers.get("X-Gateway-Key").map(String::as_str), Some("abc123"));
         assert_eq!(headers.get("X-Tenant").map(String::as_str), Some("acme"));
+
+        let round_tripped: LlmConfig =
+            serde_json::from_str(&serde_json::to_string(&cfg).expect("serialize")).expect("deserialize");
+        assert_eq!(round_tripped, cfg);
+    }
+
+    #[test]
+    fn test_llm_config_max_concurrency_round_trip() {
+        let cfg: LlmConfig = toml::from_str(
+            r#"
+model = "openai/gpt-4o"
+max_concurrency = 3
+"#,
+        )
+        .expect("deserialize LlmConfig from TOML");
+        assert_eq!(cfg.max_concurrency, Some(3));
 
         let round_tripped: LlmConfig =
             serde_json::from_str(&serde_json::to_string(&cfg).expect("serialize")).expect("deserialize");

--- a/crates/xberg/src/extraction/image_ocr.rs
+++ b/crates/xberg/src/extraction/image_ocr.rs
@@ -12,9 +12,10 @@
 //!
 //! # Concurrency
 //!
-//! Image OCR tasks are processed with a bounded concurrency limit
-//! derived from the configured thread budget to prevent resource
-//! exhaustion when documents contain many embedded images.
+//! Image OCR tasks within one extraction operation are processed with a bounded
+//! concurrency limit derived from the VLM request limit, when configured, or the
+//! general thread budget otherwise to prevent resource exhaustion when documents
+//! contain many embedded images.
 
 use crate::types::{ExtractedDocument, ExtractedImage};
 
@@ -35,8 +36,10 @@ use crate::types::{ExtractedDocument, ExtractedImage};
 ///
 /// # Concurrency
 ///
-/// Concurrency is bounded by the configured thread budget using a replenished
-/// task set, so queued images do not create an unbounded number of futures.
+/// Concurrency within the current extraction is bounded by the configured VLM
+/// request limit (falling back to the thread budget) using a replenished task set,
+/// so queued images do not create an unbounded number of futures. Concurrent
+/// document extractions each enforce their own limit.
 #[cfg(all(feature = "ocr", feature = "tokio-runtime"))]
 pub(crate) async fn process_images_with_ocr(
     mut images: Vec<ExtractedImage>,
@@ -54,7 +57,7 @@ pub(crate) async fn process_images_with_ocr(
     use std::collections::VecDeque;
     use tokio::task::JoinSet;
 
-    let max_tasks = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
+    let max_tasks = crate::core::config::concurrency::resolve_ocr_concurrency(ocr_config, config.concurrency.as_ref());
 
     type OcrTaskResult = (usize, crate::Result<ExtractedDocument>);
     type PendingOcrTask = (usize, bytes::Bytes, crate::core::config::OcrConfig);
@@ -135,4 +138,135 @@ pub(crate) async fn process_images_with_ocr(
     }
 
     Ok(images)
+}
+
+#[cfg(all(test, feature = "ocr", feature = "tokio-runtime"))]
+mod tests {
+    use std::borrow::Cow;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use tokio::sync::Barrier;
+
+    use super::*;
+    use crate::core::config::{ConcurrencyConfig, LlmConfig, OcrConfig, VlmFallbackPolicy};
+    use crate::plugins::{OcrBackend, OcrBackendType, Plugin};
+
+    const BACKEND_NAME: &str = "vlm-concurrency-test-backend";
+
+    struct RegistrationGuard;
+
+    impl Drop for RegistrationGuard {
+        fn drop(&mut self) {
+            let _ = crate::plugins::unregister_ocr_backend(BACKEND_NAME);
+        }
+    }
+
+    struct MeasuringBackend {
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        calls: Arc<AtomicUsize>,
+        first_wave: Arc<Barrier>,
+    }
+
+    impl Plugin for MeasuringBackend {
+        fn name(&self) -> &str {
+            BACKEND_NAME
+        }
+
+        fn version(&self) -> String {
+            "1.0.0".to_string()
+        }
+
+        fn initialize(&self) -> crate::Result<()> {
+            Ok(())
+        }
+
+        fn shutdown(&self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl OcrBackend for MeasuringBackend {
+        async fn process_image(&self, _image_bytes: &[u8], _config: &OcrConfig) -> crate::Result<ExtractedDocument> {
+            let call_index = self.calls.fetch_add(1, Ordering::SeqCst);
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak.fetch_max(active, Ordering::SeqCst);
+
+            // The first two calls meet here. A regression that permits only one task
+            // times out; one that launches more than two is captured by `peak`.
+            if call_index < 2 {
+                self.first_wave.wait().await;
+            }
+
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(ExtractedDocument {
+                content: format!("image {call_index}"),
+                mime_type: Cow::Borrowed("text/plain"),
+                ..Default::default()
+            })
+        }
+
+        fn supports_language(&self, _lang: &str) -> bool {
+            true
+        }
+
+        fn backend_type(&self) -> OcrBackendType {
+            OcrBackendType::Custom
+        }
+    }
+
+    #[tokio::test]
+    async fn per_llm_limit_bounds_actual_in_flight_image_ocr_requests() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::new(AtomicUsize::new(0));
+        crate::plugins::register_ocr_backend(Arc::new(MeasuringBackend {
+            active: Arc::clone(&active),
+            peak: Arc::clone(&peak),
+            calls: Arc::clone(&calls),
+            first_wave: Arc::new(Barrier::new(2)),
+        }))
+        .expect("register measuring OCR backend");
+        let _registration = RegistrationGuard;
+
+        let config = crate::core::config::ExtractionConfig {
+            ocr: Some(OcrConfig {
+                backend: BACKEND_NAME.to_string(),
+                vlm_fallback: VlmFallbackPolicy::Always,
+                vlm_config: Some(LlmConfig {
+                    model: "test/model".to_string(),
+                    max_concurrency: Some(2),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            concurrency: Some(ConcurrencyConfig { max_threads: Some(8) }),
+            ..Default::default()
+        };
+        let images = (0..6)
+            .map(|_| ExtractedImage {
+                data: Bytes::from_static(b"image"),
+                ..Default::default()
+            })
+            .collect();
+        let mut warnings = Vec::new();
+
+        let processed = tokio::time::timeout(
+            Duration::from_secs(5),
+            process_images_with_ocr(images, &config, &mut warnings),
+        )
+        .await
+        .expect("configured concurrency should allow the first wave to run")
+        .expect("image OCR should succeed");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 6);
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
+        assert!(warnings.is_empty());
+        assert!(processed.iter().all(|image| image.ocr_result.is_some()));
+    }
 }

--- a/crates/xberg/src/extractors/pdf/ocr.rs
+++ b/crates/xberg/src/extractors/pdf/ocr.rs
@@ -1020,7 +1020,8 @@ pub(crate) async fn extract_mixed_ocr_native(
         ocr_config_resolved.acceleration = config.acceleration.clone();
     }
 
-    let batch_size = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
+    let batch_size =
+        crate::core::config::concurrency::resolve_ocr_concurrency(&ocr_config_resolved, config.concurrency.as_ref());
 
     let capture_rasters = config.images.as_ref().is_some_and(|c| c.include_page_rasters);
     let ocr_config_owned = ensure_elements_enabled(&ocr_config_resolved);
@@ -2401,7 +2402,8 @@ pub(crate) async fn extract_with_ocr(
     #[cfg(all(feature = "tokio-runtime", not(target_arch = "wasm32")))]
     use tokio::task::JoinSet;
 
-    let configured_batch_size = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
+    let configured_batch_size =
+        crate::core::config::concurrency::resolve_ocr_concurrency(ocr_config, config.concurrency.as_ref());
 
     let batch_size = if images.is_none() {
         adapt_batch_size_to_memory(configured_batch_size, content.map(|b| b.len()).unwrap_or(0))

--- a/crates/xberg/src/plugins/processor/builtin/captioning.rs
+++ b/crates/xberg/src/plugins/processor/builtin/captioning.rs
@@ -83,10 +83,11 @@ impl PostProcessor for CaptioningProcessor {
         use std::collections::VecDeque;
         use tokio::task::JoinSet;
 
-        // Bound VLM captioning concurrency by the configured thread budget so an
-        // image-heavy document does not spawn an unbounded number of in-flight VLM
-        // requests. Mirrors the image-OCR path's replenished task set (#1378).
-        let max_tasks = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
+        // Bound VLM captioning concurrency by the per-LLM request limit when set,
+        // falling back to the configured thread budget for backward compatibility.
+        // Mirrors the image-OCR path's replenished task set (#1378).
+        let max_tasks =
+            crate::core::config::concurrency::resolve_llm_concurrency(&caption_config.llm, config.concurrency.as_ref());
 
         type CaptionOutcome = crate::Result<(String, Option<crate::types::LlmUsage>)>;
         type PendingCaptionTask = (usize, bytes::Bytes, &'static str);

--- a/fixtures/contract/config_llm_max_concurrency.json
+++ b/fixtures/contract/config_llm_max_concurrency.json
@@ -1,0 +1,53 @@
+{
+	"id": "config_llm_max_concurrency",
+	"description": "Tests that LLM max_concurrency is accepted independently of the extraction thread budget",
+	"docs": {
+		"topic": "contract",
+		"title": "Configure per-LLM concurrency",
+		"description": "Tests that LLM max_concurrency is accepted independently of the extraction thread budget",
+		"side_effects": "server"
+	},
+	"tags": ["contract", "config", "llm", "concurrency"],
+	"call": "extract",
+	"input": {
+		"mock_responses": [
+			{
+				"path": "/text/report.txt",
+				"status_code": 200,
+				"headers": {
+					"content-type": "application/octet-stream"
+				},
+				"body_file": "../test_documents/text/report.txt"
+			}
+		],
+		"extract_input": {
+			"kind": "uri",
+			"uri": "$mock_url/text/report.txt",
+			"mime_type": "text/plain"
+		}
+	},
+	"assertions": [
+		{
+			"type": "equals",
+			"field": "results[0].mime_type",
+			"value": "text/plain"
+		},
+		{
+			"type": "min_length",
+			"field": "results[0].content",
+			"value": 5
+		}
+	],
+	"config": {
+		"concurrency": {
+			"max_threads": 8
+		},
+		"captioning": {
+			"llm": {
+				"model": "openai/gpt-4o",
+				"max_concurrency": 2
+			},
+			"min_image_area": 1000
+		}
+	}
+}


### PR DESCRIPTION
## Description

Add max_concurrency to LlmConfig and use it to bound VLM OCR and image-captioning requests in flight within one extraction. When unset, these paths continue to use ConcurrencyConfig.max_threads, preserving existing behavior.

max_threads represents local CPU capacity. VLM calls are asynchronous. They spend most of their lifetime waiting for remote inference rather than using a local CPU. Coupling the two limits therefore underutilizes provider capacity when CPU concurrency is deliberately conservative. Separating them lets deployments increase VLM parallelism without increasing CPU-bound extraction work.

For explicit OCR pipelines, resolve the most conservative configured limit across VLM stages. Keep the new field last in LlmConfig to preserve positional constructors in generated bindings. Cover the setting with configuration, fixture, resolver, and in-flight concurrency tests.

## Checklist

- [ ] CI passing
- [X] Tests added where applicable
