### PR TITLE
fix(api): read OpenWebUI's flattened Docling parameters

### DIFF
--- a/crates/xberg/src/api/openweb.rs
+++ b/crates/xberg/src/api/openweb.rs
@@ -123,6 +123,17 @@ pub(crate) async fn openweb_docling_handler(
 ) -> Result<Json<DoclingCompatResponse>, ApiError> {
     let mut file_data: Option<(Vec<u8>, String)> = None;
     let mut config_json: Option<String> = None;
+    let mut flat_config = serde_json::Map::new();
+
+    // OpenWebUI's Docling client sends one form field per parameter rather than a JSON blob,
+    // so the keys of the serialized base config are what identify a field as configuration.
+    // Matching on them keeps Docling's own knobs (`image_export_mode`,
+    // `md_page_break_placeholder`) ignored instead of failing the whole request against
+    // `ExtractionConfig`'s `deny_unknown_fields`.
+    let config_keys = match serde_json::to_value(&*state.default_config) {
+        Ok(serde_json::Value::Object(keys)) => keys,
+        _ => serde_json::Map::new(),
+    };
 
     while let Some(field) = multipart
         .next_field()
@@ -152,8 +163,8 @@ pub(crate) async fn openweb_docling_handler(
 
                 file_data = Some((data.to_vec(), mime_type));
             }
-            // OpenWebUI's Docling engine sends extraction parameters as a form field. Accept
-            // the /extract field name "config" as well as OpenWebUI's own "parameters" label.
+            // A client that sends the whole config as one JSON blob: the /extract field name
+            // "config", or the "parameters" label.
             "config" | "parameters" => {
                 let text = field
                     .text()
@@ -163,8 +174,19 @@ pub(crate) async fn openweb_docling_handler(
                     config_json = Some(text);
                 }
             }
+            name if config_keys.contains_key(name) => {
+                let text = field
+                    .text()
+                    .await
+                    .map_err(|e| ApiError::validation(crate::error::XbergError::validation(e.to_string())))?;
+                flat_config.insert(name.to_string(), form_value_to_json(&text));
+            }
             _ => {}
         }
+    }
+
+    if config_json.is_none() && !flat_config.is_empty() {
+        config_json = Some(serde_json::Value::Object(flat_config).to_string());
     }
 
     let (data, mime_type) = file_data.ok_or_else(|| {
@@ -195,6 +217,18 @@ pub(crate) async fn openweb_docling_handler(
         },
         status: "success".to_string(),
     }))
+}
+
+/// Convert one multipart form value into JSON for the config merge.
+///
+/// Form values are always strings, and OpenWebUI's Python client renders booleans as
+/// `True`/`False`, which no JSON parser accepts.
+fn form_value_to_json(raw: &str) -> serde_json::Value {
+    match raw.trim() {
+        "True" => serde_json::Value::Bool(true),
+        "False" => serde_json::Value::Bool(false),
+        trimmed => serde_json::from_str(trimmed).unwrap_or_else(|_| serde_json::Value::String(raw.to_string())),
+    }
 }
 
 #[cfg(test)]
@@ -254,6 +288,52 @@ mod tests {
         }
         body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
         body
+    }
+
+    /// A body in the shape OpenWebUI's `DoclingLoader` actually sends: the file plus one
+    /// form field per parameter, rather than a single JSON blob.
+    fn docling_body_with_fields(boundary: &str, fields: &[(&str, &str)]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"files\"; filename=\"plain.txt\"\r\nContent-Type: text/plain\r\n\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(&fixture_bytes());
+        body.extend_from_slice(b"\r\n");
+        for (name, value) in fields {
+            body.extend_from_slice(
+                format!("--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n")
+                    .as_bytes(),
+            );
+        }
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    async fn docling_flat_response(fields: &[(&str, &str)]) -> (StatusCode, String) {
+        let app = test_router();
+        let boundary = "flatboundary";
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/convert/file")
+                    .header("content-type", format!("multipart/form-data; boundary={boundary}"))
+                    .body(Body::from(docling_body_with_fields(boundary, fields)))
+                    .expect("valid request"),
+            )
+            .await
+            .expect("handler responded");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes readable");
+        let content = serde_json::from_slice::<DoclingCompatResponse>(&bytes)
+            .map(|parsed| parsed.document.md_content)
+            .unwrap_or_default();
+        (status, content)
     }
 
     async fn docling_md_content(config: Option<&str>) -> String {
@@ -448,6 +528,99 @@ mod tests {
             markdown, json,
             "config output_format should change the rendered content"
         );
+    }
+
+    /// OpenWebUI flattens its parameters into one form field per key, so a flattened field
+    /// has to reach the config instead of being dropped.
+    #[tokio::test]
+    async fn openweb_docling_flat_form_field_changes_output() {
+        let markdown = docling_md_content(None).await;
+        let (status, json) = docling_flat_response(&[("output_format", "json")]).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_ne!(markdown, json, "a flattened output_format field must reach the config");
+    }
+
+    /// `image_export_mode` and `md_page_break_placeholder` are Docling's own parameters and
+    /// are sent on every OpenWebUI request. They have no xberg equivalent, so they must stay
+    /// ignored rather than failing the request.
+    #[tokio::test]
+    async fn openweb_docling_ignores_docling_only_form_fields() {
+        let markdown = docling_md_content(None).await;
+        let (status, json) = docling_flat_response(&[
+            ("image_export_mode", "placeholder"),
+            ("md_page_break_placeholder", "\u{c}"),
+            ("output_format", "json"),
+        ])
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_ne!(markdown, json);
+    }
+
+    /// The parameter set from the report, in the encoding OpenWebUI's Python client produces:
+    /// every value a string, booleans rendered `True`/`False`. `output_format` carries the
+    /// assertion because the reporter's own values all render identically to the defaults,
+    /// which is why the bug was invisible from the response alone.
+    #[tokio::test]
+    async fn openweb_docling_accepts_python_rendered_form_values() {
+        let markdown = docling_md_content(None).await;
+        let (status, json) = docling_flat_response(&[
+            ("image_export_mode", "placeholder"),
+            ("force_ocr", "False"),
+            ("output_format", "json"),
+            ("extraction_timeout_secs", "7200"),
+            ("disable_ocr", "True"),
+        ])
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "Python-rendered values must coerce, not 400");
+        assert_ne!(markdown, json, "the flattened parameters must reach the config");
+    }
+
+    /// An explicit JSON blob keeps precedence over flattened fields.
+    #[tokio::test]
+    async fn openweb_docling_config_blob_wins_over_flat_fields() {
+        let app = test_router();
+        let boundary = "bothboundary";
+        let mut body = docling_body_with_fields(boundary, &[("output_format", "json")]);
+        let closing = format!("--{boundary}--\r\n");
+        body.truncate(body.len() - closing.len());
+        body.extend_from_slice(
+            format!("--{boundary}\r\nContent-Disposition: form-data; name=\"config\"\r\n\r\n{{\"output_format\":\"markdown\"}}\r\n")
+                .as_bytes(),
+        );
+        body.extend_from_slice(closing.as_bytes());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/convert/file")
+                    .header("content-type", format!("multipart/form-data; boundary={boundary}"))
+                    .body(Body::from(body))
+                    .expect("valid request"),
+            )
+            .await
+            .expect("handler responded");
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes readable");
+        let content = serde_json::from_slice::<DoclingCompatResponse>(&bytes)
+            .expect("response parses")
+            .document
+            .md_content;
+
+        assert_eq!(content, docling_md_content(None).await, "the blob must win");
+    }
+
+    #[test]
+    fn form_values_coerce_python_literals_and_numbers() {
+        assert_eq!(form_value_to_json("True"), serde_json::json!(true));
+        assert_eq!(form_value_to_json("False"), serde_json::json!(false));
+        assert_eq!(form_value_to_json("7200"), serde_json::json!(7200));
+        assert_eq!(form_value_to_json("markdown"), serde_json::json!("markdown"));
     }
 
     /// The Docling endpoint honors the server's user config as the base when no per-request


### PR DESCRIPTION
## Related

Closes #1461

## Description

OpenWebUI's Docling client sends extraction parameters as **one form field per key**, not as a
single JSON blob. `openweb_docling_handler` matched only `config`/`parameters` and discarded
everything else through its `_ => {}` arm, so a configuration set in OpenWebUI's admin UI never
reached the pipeline. The extraction succeeded and the output was byte-identical with or without
parameters, which is exactly what the report describes.

### Where the parameters actually go

[`DoclingLoader.load()`](https://github.com/open-webui/open-webui/blob/v0.11.0/backend/open_webui/retrieval/loaders/main.py#L197-L213)
parses the admin UI's Parameters box (`DOCLING_PARAMS`) with `json.loads` and then spreads it into
the form:

```python
data={
    'image_export_mode': 'placeholder',
    'md_page_break_placeholder': page_break_marker,
    **self.params,
},
```

So for the configuration in the report, what arrives is:

```
image_export_mode         = 'placeholder'
md_page_break_placeholder = '\x0c'
force_ocr                 = 'False'
output_format             = 'markdown'
extraction_timeout_secs   = '7200'
disable_ocr               = 'True'
```

The previous fix for this complaint added the `config`/`parameters` field names on the assumption
that a JSON blob was being sent. That premise was wrong, which is why 1.0.14 did not change the
behaviour.

### The fix

A form field whose name is a key of the serialized base config is folded into a config override.
Three details matter:

- **Docling's own parameters stay ignored.** OpenWebUI sends `image_export_mode` and
  `md_page_break_placeholder` on every request and neither is an xberg field. Matching on the base
  config's keys rather than forwarding everything keeps those from failing the whole request
  against `ExtractionConfig`'s `deny_unknown_fields` — forwarding blindly would turn a silent
  no-op into a 400 for every OpenWebUI user.
- **Values are coerced.** Form values are always strings and the Python client renders booleans as
  `True`/`False`, which no JSON parser accepts.
- **An explicit `config`/`parameters` blob keeps precedence**, so the existing behaviour is
  unchanged for clients that send one.

### Limits worth stating

- A field that is `Option<T>` with `skip_serializing_if = "Option::is_none"` and currently `None`
  is absent from the serialized base config, so it is not settable this way. That is `qr_codes`
  and `force_ocr_pages` plus eight nested config objects. Happy to switch to a different source
  for the key set if you would rather have full coverage.
- Nested configuration cannot travel this path at all, independently of xberg: `requests`
  iterates a dict value, so `{"layout": {"table_model": "slanet_wired"}}` leaves the client as
  `layout = 'table_model'` with the value already lost. The second configuration in the report is
  undeliverable by OpenWebUI, not dropped by us.
- `md_page_break_placeholder` is unimplemented crate-wide, so OpenWebUI's per-page splitting never
  happens for xberg. That looked like a separate defect and is deliberately not in this PR.

## Checklist

- [ ] CI passing — see the note below on two gates that are already red on `main`
- [x] Tests added where applicable

Four new tests, three of which fail without the change:

| test | fails without the fix |
|---|---|
| `openweb_docling_flat_form_field_changes_output` | yes |
| `openweb_docling_ignores_docling_only_form_fields` | yes |
| `openweb_docling_accepts_python_rendered_form_values` | yes |
| `openweb_docling_config_blob_wins_over_flat_fields` | no — it pins the precedence rule |

Plus a unit test on the value coercion. `cargo test --locked -p xberg --features api --lib` is
green at 2055 passed, and `cargo fmt -p xberg -- --check` is clean.

### Two gates are already failing on `main`

Both reproduce on a clean `main` with this branch's changes reverted, and every file involved is
byte-identical to `main` here:

- `cargo fmt --all -- --check` fails in `crates/xberg-py/src/lib.rs` and
  `packages/dart/rust/src/frb_generated.rs`, both generated.
- `cargo clippy --locked -p xberg --features full --all-targets -- -D warnings` reports 10 errors,
  6 of them in `crates/xberg/src/extractors/pdf/ocr.rs` and the rest in `comrak_bridge.rs`,
  `pdf/structure/adapters.rs`, `ocr/processor/config.rs` and `extractors/pdf/mod.rs`
  (`needless_return`, `too_many_arguments`, `needless_range_loop`, `type_complexity`).

Clippy reports nothing in `crates/xberg/src/api/openweb.rs`. I have deliberately not touched any of
those files — reformatting two generated files or silencing lints across five unrelated ones did not
belong in this PR. Say the word if you would like either as a separate one.
