### PR TITLE
fix(clippy): repair the clippy gate on main

### DIFF
--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -294,6 +294,7 @@ fn select_native_pdf_document(
 }
 
 #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+#[allow(clippy::too_many_arguments)]
 fn select_pdf_document(
     extraction_method: ExtractionMethod,
     text: &str,

--- a/crates/xberg/src/extractors/pdf/ocr.rs
+++ b/crates/xberg/src/extractors/pdf/ocr.rs
@@ -3491,10 +3491,10 @@ fn ocr_points_per_pixel(
         if page_height_px == 0 {
             return 1.0;
         }
-        return lazy_pdf_render_state
+        lazy_pdf_render_state
             .map(|(doc, _, _)| page_dimensions_pt(doc, page_idx).1 / page_height_px as f32)
             .filter(|scale| scale.is_finite() && *scale > 0.0)
-            .unwrap_or(1.0);
+            .unwrap_or(1.0)
     }
     #[cfg(not(feature = "pdf"))]
     {
@@ -3940,6 +3940,7 @@ pub(crate) async fn extract_with_ocr(
 /// it, `content: None` makes the lookup fall back to `1.0` (pixels treated as points), silently
 /// defeating the document-global heading heuristic's absolute-point font-gap comparisons.
 #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+#[allow(clippy::too_many_arguments)]
 async fn extract_with_ocr_for_page(
     content: Option<&[u8]>,
     images: Option<&[image::DynamicImage]>,
@@ -5056,12 +5057,12 @@ async fn recover_pipeline_document_from_image_xobjects(
     let mut page_texts = vec![String::new(); page_count];
     let mut recovered_images: Vec<crate::types::ExtractedImage> = Vec::new();
     let mut warnings: Vec<crate::types::ProcessingWarning> = Vec::new();
-    for page_idx in 0..page_count {
+    for (page_idx, page_text) in page_texts.iter_mut().enumerate() {
         let Some(recovery) = recover_page_text_from_image_xobjects(&backend, &doc, page_idx, ocr_config).await else {
             continue;
         };
         if !recovery.text.is_empty() {
-            page_texts[page_idx] = recovery.text;
+            *page_text = recovery.text;
             warnings.push(xobject_fallback_warning(page_idx, recovery.attempted));
         }
         recovered_images.extend(recovery.images);
@@ -5158,6 +5159,7 @@ pub(crate) async fn run_ocr_pipeline(
 /// `points_per_pixel_override` is likewise forwarded verbatim to every stage's
 /// [`extract_with_ocr_for_page`] call. See that function's doc comments for why both exist.
 #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+#[allow(clippy::too_many_arguments)]
 async fn run_ocr_pipeline_for_page(
     content: Option<&[u8]>,
     images: Option<&[image::DynamicImage]>,
@@ -11124,7 +11126,7 @@ Name: ___
         );
         let all_kinds: Vec<_> = structured_pages
             .values()
-            .flat_map(|doc| doc.elements.iter().map(|e| e.kind.clone()))
+            .flat_map(|doc| doc.elements.iter().map(|e| e.kind))
             .collect();
         assert!(
             all_kinds
@@ -11280,7 +11282,7 @@ Name: ___
         );
         let all_kinds: Vec<_> = structured_pages
             .values()
-            .flat_map(|doc| doc.elements.iter().map(|e| e.kind.clone()))
+            .flat_map(|doc| doc.elements.iter().map(|e| e.kind))
             .collect();
         assert!(
             all_kinds

--- a/crates/xberg/src/ocr/processor/config.rs
+++ b/crates/xberg/src/ocr/processor/config.rs
@@ -368,6 +368,7 @@ mod tests {
         let baseline = create_test_config();
         let baseline_hash = hash_config(&baseline);
 
+        #[allow(clippy::type_complexity)]
         let flips: Vec<(&str, Box<dyn Fn(&mut TesseractConfig)>)> = vec![
             (
                 "classify_use_pre_adapted_templates",

--- a/crates/xberg/src/pdf/structure/adapters.rs
+++ b/crates/xberg/src/pdf/structure/adapters.rs
@@ -1719,6 +1719,7 @@ fn make_ocr_paragraph(
 }
 
 #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+#[allow(clippy::too_many_arguments)]
 fn make_ocr_pdf_line(
     text: &str,
     x: f32,

--- a/crates/xberg/src/rendering/comrak_bridge.rs
+++ b/crates/xberg/src/rendering/comrak_bridge.rs
@@ -512,13 +512,13 @@ const BULLET_MARKER_CHARS: &[char] = &['-', '*', '•', '‣', '◦'];
 /// marker is present, leaving genuine content untouched.
 fn redundant_list_marker_len(text: &str) -> usize {
     let mut chars = text.chars();
-    if let Some(first) = chars.next() {
-        if BULLET_MARKER_CHARS.contains(&first) {
-            let bullet_len = first.len_utf8();
-            let rest = &text[bullet_len..];
-            let space_len = rest.len() - rest.trim_start_matches(' ').len();
-            return if space_len > 0 { bullet_len + space_len } else { 0 };
-        }
+    if let Some(first) = chars.next()
+        && BULLET_MARKER_CHARS.contains(&first)
+    {
+        let bullet_len = first.len_utf8();
+        let rest = &text[bullet_len..];
+        let space_len = rest.len() - rest.trim_start_matches(' ').len();
+        return if space_len > 0 { bullet_len + space_len } else { 0 };
     }
 
     let digits_len = text.find(|c: char| !c.is_ascii_digit()).unwrap_or(text.len());


### PR DESCRIPTION
## Related

Closes #1463

## Description

`cargo clippy --locked -p xberg --features full --all-targets -- -D warnings`, the command the
`Rust (*)` jobs run, has been failing on `main` since 2026-08-18 with 10 errors. All four platform
legs are red on every PR, so the gate cannot currently distinguish a contributor's regression from
`main`'s own state. This makes it pass again.

### Five are mechanical and behaviour preserving

| lint | file | change |
|---|---|---|
| `clone_on_copy` ×2 | `extractors/pdf/ocr.rs` | `ElementKind` is `Copy`, so `e.kind.clone()` becomes `e.kind` |
| `needless_return` | `extractors/pdf/ocr.rs` | the `return` was on the tail expression of the `#[cfg(feature = "pdf")]` block |
| `needless_range_loop` | `extractors/pdf/ocr.rs` | `for page_idx in 0..page_count` indexing `page_texts` becomes `page_texts.iter_mut().enumerate()` |
| `collapsible_if` | `rendering/comrak_bridge.rs` | nested `if let` / `if` becomes one let-chain |

### Five follow the existing suppression pattern

Four `too_many_arguments` (`extract_with_ocr_for_page`, `run_ocr_pipeline_for_page`,
`select_pdf_document`, `make_ocr_pdf_line`) and one `type_complexity` in a test binding.

These two lints are already treated as advisory in this crate rather than actionable:
`allow(clippy::too_many_arguments)` appears 16 times across 12 files, and
`allow(clippy::type_complexity)` 8 times across 4 files, four of those in
`extractors/pdf/ocr.rs` itself. Placement matches the house pattern of `#[cfg]` then `#[allow]`
immediately above the item, as in `pdf/structure/regions/table_recognition.rs`, and the
`type_complexity` allow sits on the `let` binding the way it already does at
`extractors/pdf/ocr.rs:5219`.

Correcting one detail from the issue: I wrote there that `too_many_arguments` was already allowed
four times in `extractors/pdf/ocr.rs`. That count belongs to `type_complexity`. `ocr.rs` carries no
`too_many_arguments` allow today, nor do `extractors/pdf/mod.rs` or `pdf/structure/adapters.rs`.
The crate-wide precedent for the lint stands at 16 occurrences in 12 files.

If you would rather the four signatures took a params struct, say so and I will close this. That is
a much larger change in hot extraction code and did not seem like the right thing to fold into a
gate repair.

### No overlap with the alef work

Every file here is hand-written core source. `alef.toml` writes into `packages/*`, `e2e` and
`docs-site/src/snippets-generated`, so nothing in this PR touches generated output or the trees the
in-flight binding work moves through.

## Checklist

- [x] CI passing, for this gate. Others noted below.
- [x] Tests added where applicable

`cargo clippy --locked -p xberg --features full --all-targets -- -D warnings` now exits 0, from 10
errors before. `cargo fmt -p xberg -- --check` is clean. `cargo test --locked -p xberg --features
full --lib` is 7165 passed, 1 failed, and that one failure is
`engine::extract_impl::tests::extract_py_local_uri_returns_source_code_mime`, which downloads a
Python tree-sitter grammar at runtime and times out on my network. It fails identically on a clean
`main` with the same message, so it is not from this change. The tests over the paths I did touch
all pass, including the four covering the XObject recovery loop and
`every_applied_tesseract_variable_moves_the_cache_key`.

No tests added: nine of the ten changes cannot alter behaviour, and the tenth, the `iter_mut`
rewrite, is already covered by those XObject recovery tests.

Still red on `main` and untouched here, since you mentioned the alef work is in progress: the two
alef freshness gates, `validate / Validate (poly)`, the iOS legs, the bindings build and the E2E
legs. For whatever it is worth from triaging them, the two freshness gates fail because
`Cargo.lock` pins `crawlberg 1.3.0` while `xberg-io/crawlberg`'s newest tag is `v1.2.1`, so
`actions/checkout` cannot resolve `ref: v1.3.0`. That one looks like a missing tag push rather than
anything in this repo.
