### PR TITLE
test(ooxml): prove the max_files_in_archive default applies when unset

### DIFF
--- a/crates/xberg/src/extraction/ooxml_embedded.rs
+++ b/crates/xberg/src/extraction/ooxml_embedded.rs
@@ -1056,4 +1056,48 @@ mod tests {
             warnings[0].message
         );
     }
+
+
+    #[tokio::test]
+    async fn test_embedded_objects_fall_back_to_default_max_files_in_archive_when_unset() {
+        // `security_limits: None` must mean "the `SecurityLimits` default", not "no limit".
+        // One entry past the default ceiling must be skipped and reported. The entries are
+        // empty so the loop skips each processed one before extraction; the test costs one
+        // ZIP central directory, not ten thousand extractions.
+        let default_limit = crate::extractors::security::SecurityLimits::default().max_files_in_archive;
+        let entries: Vec<String> = (0..=default_limit)
+            .map(|i| format!("word/embeddings/blob{i}"))
+            .collect();
+        let entry_refs: Vec<(&str, &[u8])> = entries.iter().map(|p| (p.as_str(), &[][..])).collect();
+        let zip_bytes = make_zip_with_files(&entry_refs);
+
+        let config = ExtractionConfig::default();
+        assert!(
+            config.security_limits.is_none(),
+            "this test must exercise the unset fallback, not an explicit limit"
+        );
+
+        let (children, warnings) =
+            extract_ooxml_embedded_objects(&zip_bytes, "word/embeddings/", "test", &config).await;
+
+        assert!(children.is_empty(), "empty entries never produce children");
+        assert_eq!(
+            warnings.len(),
+            1,
+            "exactly one cap warning expected, nothing else: {:?}",
+            warnings
+        );
+        assert!(
+            warnings[0].message.contains("Skipped 1 "),
+            "exactly one entry past the default ceiling must be skipped: {}",
+            warnings[0].message
+        );
+        assert!(
+            warnings[0]
+                .message
+                .contains(&format!("max_files_in_archive ({default_limit})")),
+            "warning must name the default limit that was hit: {}",
+            warnings[0].message
+        );
+    }
 }

--- a/crates/xberg/src/extractors/docx.rs
+++ b/crates/xberg/src/extractors/docx.rs
@@ -4031,4 +4031,48 @@ mod tests {
             internal_doc.elements
         );
     }
+
+
+    /// With no `security_limits` override the container must still enforce the default
+    /// `SecurityLimits::max_files_in_archive`: "unset" means the default ceiling, not "no
+    /// ceiling". One entry past that default must be rejected.
+    #[tokio::test]
+    async fn test_docx_extract_content_rejects_archive_over_default_entry_limit() {
+        let default_limit = crate::extractors::security::SecurityLimits::default().max_files_in_archive;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body>
+</w:document>"#;
+        // The builder adds its own fixed parts, so this alone already exceeds the ceiling.
+        let extra_files: Vec<(String, String)> = (0..=default_limit)
+            .map(|i| (format!("word/extra_{}.xml", i), "<x/>".to_string()))
+            .collect();
+        let extra_refs: Vec<(&str, &str)> = extra_files.iter().map(|(p, x)| (p.as_str(), x.as_str())).collect();
+        let data = build_test_docx_with_files(document_xml, &extra_refs);
+
+        let extractor = DocxExtractor::new();
+        let config = ExtractionConfig::default();
+        assert!(
+            config.security_limits.is_none(),
+            "this test must exercise the unset fallback, not an explicit limit"
+        );
+
+        let result = extractor
+            .extract_content(
+                &data,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                &config,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "an archive over the default max_files_in_archive must be rejected when no limit is configured"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains(&default_limit.to_string()),
+            "error should mention the default limit ({default_limit}), got: {err_msg}"
+        );
+    }
 }

--- a/crates/xberg/src/extractors/excel.rs
+++ b/crates/xberg/src/extractors/excel.rs
@@ -1332,4 +1332,44 @@ mod tests {
             pages
         );
     }
+
+
+    /// With no `security_limits` override the container must still enforce the default
+    /// `SecurityLimits::max_files_in_archive`: "unset" means the default ceiling, not "no
+    /// ceiling". An archive past that default must be rejected.
+    #[cfg(feature = "excel")]
+    #[tokio::test]
+    async fn test_xlsx_extract_content_rejects_archive_over_default_entry_limit() {
+        let default_limit = crate::extractors::security::SecurityLimits::default().max_files_in_archive;
+        // `build_test_xlsx` writes five fixed parts of its own, so this alone already
+        // exceeds the ceiling. Rebased onto the current helper, which takes the extra
+        // parts as a slice rather than a count.
+        let names: Vec<String> = (0..=default_limit).map(|i| format!("xl/extra_{i}.xml")).collect();
+        let extra_parts: Vec<(&str, &[u8])> = names.iter().map(|n| (n.as_str(), b"<x/>".as_slice())).collect();
+        let data = build_test_xlsx(&extra_parts);
+        let extractor = ExcelExtractor::new();
+        let config = ExtractionConfig::default();
+        assert!(
+            config.security_limits.is_none(),
+            "this test must exercise the unset fallback, not an explicit limit"
+        );
+
+        let result = extractor
+            .extract_content(
+                &data,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                &config,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "an archive over the default max_files_in_archive must be rejected when no limit is configured"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains(&default_limit.to_string()),
+            "error should mention the default limit ({default_limit}), got: {err_msg}"
+        );
+    }
 }

--- a/crates/xberg/src/extractors/pptx.rs
+++ b/crates/xberg/src/extractors/pptx.rs
@@ -1405,4 +1405,45 @@ mod tests {
             result.err()
         );
     }
+
+
+    /// With no `security_limits` override the container must still enforce the default
+    /// `SecurityLimits::max_files_in_archive`: "unset" means the default ceiling, not "no
+    /// ceiling". One entry past that default must be rejected.
+    #[tokio::test]
+    async fn test_pptx_extract_content_rejects_archive_over_default_entry_limit() {
+        use crate::core::config::ExtractionConfig;
+
+        let default_limit = crate::extractors::security::SecurityLimits::default().max_files_in_archive;
+        let slide_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+    <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>Hello</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+</p:sld>"#;
+        // The builder adds its own fixed parts, so this alone already exceeds the ceiling.
+        let extra_parts: Vec<(String, Vec<u8>)> = (0..=default_limit)
+            .map(|i| (format!("ppt/extra_{}.xml", i), b"<x/>".to_vec()))
+            .collect();
+        let extra_refs: Vec<(&str, &[u8])> = extra_parts.iter().map(|(p, d)| (p.as_str(), d.as_slice())).collect();
+        let pptx = crate::extraction::pptx::tests::build_single_slide_pptx(slide_xml, None, &extra_refs);
+
+        let extractor = PptxExtractor::new();
+        let mime = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+        let config = ExtractionConfig::default();
+        assert!(
+            config.security_limits.is_none(),
+            "this test must exercise the unset fallback, not an explicit limit"
+        );
+
+        let result = extractor.extract_content(&pptx, mime, &config).await;
+        assert!(
+            result.is_err(),
+            "an archive over the default max_files_in_archive must be rejected when no limit is configured"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains(&default_limit.to_string()),
+            "error should mention the default limit ({default_limit}), got: {err_msg}"
+        );
+    }
 }


### PR DESCRIPTION
## Related

Closes #1449

## Description

The cap itself is on `main`: 666729a5f bounds the embedded-object loop and warns on truncation, and 65da55daa threads the configured limit into the DOCX and PPTX containers (XLSX followed in the same shape). This adds the coverage those commits left out.

### What the existing tests do not prove

Every site reads the limit with `security_limits.clone().unwrap_or_default().max_files_in_archive`. The existing tests set an explicit limit, or show that a small document passes under the default. None proves that an unset `security_limits` enforces the `SecurityLimits` default of 10,000. A fallback of "no limit" passes every current test; it fails each of the four tests here.

### The tests

One test per file builds an archive past the default ceiling and extracts it with `ExtractionConfig::default()`.

| Site | Input | Expected |
|---|---|---|
| `extract_ooxml_embedded_objects` | 10,001 empty entries under `word/embeddings/` | exactly one warning: `Skipped 1 ... max_files_in_archive (10000)` |
| DOCX container | 10,001 extra parts | an error that names `10000` |
| PPTX container | 10,001 extra parts | an error that names `10000` |
| XLSX container | 10,001 extra parts | an error that names `10000` |

The embedded-object test uses empty entries, so the loop skips each one before extraction. The test costs one ZIP central directory, not ten thousand extractions.

## Verification

`cargo test -p xberg --lib --features office,excel`, run at this branch on two separate 16-core Linux boxes. Both show `Compiling xberg v1.1.0`, so neither result comes from a stale binary:

```
test result: ok. 2628 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.25s
test result: ok. 2628 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.37s
```

`XBERG_SKIP_TEST_DOCUMENTS=1` is set. Without it the two `vendored_docling_corpus` tests fail on `main` and on this branch alike, because `test_documents` is not populated on those boxes. Nothing else in the run differs.

### The tests fail without the behaviour

Replacing the fallback at all seven read sites with `map_or(usize::MAX, |l| l.max_files_in_archive)` — that is, "unset means no limit" — and running the whole suite unfiltered:

```
test extraction::ooxml_embedded::tests::test_embedded_objects_fall_back_to_default_max_files_in_archive_when_unset ... FAILED
test extractors::docx::tests::test_docx_extract_content_rejects_archive_over_default_entry_limit ... FAILED
test extractors::pptx::tests::test_pptx_extract_content_rejects_archive_over_default_entry_limit ... FAILED
test extractors::excel::tests::test_xlsx_extract_content_rejects_archive_over_default_entry_limit ... FAILED
test result: FAILED. 2624 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.44s
```

`2624 + 4 = 2628` says two things at once. Every new test is load-bearing, and none of them over-asserts: exactly the four fail, and no unrelated test is disturbed. A mutation that took other tests with it would mean the new assertions were coupled to something they should not care about.

### The mutation was reverted cleanly

Afterwards `git checkout -- .` restores the tree, `git status --porcelain` is empty, `grep -c 'map_or(usize::MAX'` returns zero, and the suite is green again at `ok. 2628 passed; 0 failed`. So no residual edit is carrying any result above.

### Lints

`cargo clippy -p xberg --features office,excel --all-targets -- -D warnings` exits 0 with zero warnings, with `Compiling xberg v1.1.0` present after touching the four files.

## CI does not exercise these tests

The Rust legs never reach the test phase. They fail to compile, in files this PR does not touch:

| Error | Site |
|---|---|
| `E0063` missing `confidence_semantics` and `page_orientation_handling` | `crates/xberg-ffi/tests/vtable_bytes_len.rs:97` |
| `E0425` cannot find `strip_dictionary_invalid_lines` | `crates/xberg/src/extractors/pdf/ocr.rs:12587` |
| `E0609` no field `0` on `String` | `packages/swift/rust/src/lib.rs:22101` |

The job log contains no occurrence of `ooxml_embedded` or `max_files_in_archive`, so none of the four tests runs there.

This is not specific to the branch. At `b6847200`, `main` was red on every workflow — CI Rust, CI Lint, CI Mobile, CI Musl Python Wheel, CI Integrations, CI E2E and CI Docker — and each of the 18 failing legs on this PR failed on `main` as well, one for one, `Narrow feature leg (formats-no-heic)` included.

`main` has moved since, and its own CI confirms this rather than leaving it to inference. At `0a603578` the CI Rust run fails on `Rust (ubuntu-latest)`, `Rust (ubuntu-24.04-arm)` and `Rust (macos-latest)`. 521a3d999 reverted the change behind the `E0425`, so that one is gone; the `E0063` at `crates/xberg-ffi/tests/vtable_bytes_len.rs:97` and the `E0609` at `packages/swift/rust/src/lib.rs:22101` both remain, and the workspace still does not build.

So a green CI run is not available for this change, and the runs above are the evidence. The `office,excel` feature set used there excludes the `pdf` module that blocks the CI legs.

## Checklist

- [ ] CI passing — blocked on `main`, see above
- [x] Tests added where applicable


