### PR TITLE
feat(core): expose cooperative cancellation to Rust callers

### DIFF
--- a/crates/xberg/src/cancellation.rs
+++ b/crates/xberg/src/cancellation.rs
@@ -2,8 +2,8 @@
 //!
 //! Provides a lightweight, FFI-friendly cancellation primitive based on
 //! `Arc<AtomicBool>`. The token can be cloned and shared across threads;
-//! any holder can cancel the operation and all other holders will observe
-//! the cancellation on their next check.
+//! any holder can request cancellation and all other holders will observe
+//! the request on their next check.
 //!
 //! # Design
 //!
@@ -15,6 +15,14 @@
 //! - The token wraps an `Arc<AtomicBool>` and can be stored in
 //!   `ExtractionConfig` without layout surprises.
 //!
+//! # Rust callers
+//!
+//! Rust callers may place one clone in `ExtractionConfig::cancel_token` and
+//! retain another clone in the application layer. Calling [`CancellationToken::cancel`]
+//! requests that extraction stop when the active pipeline reaches its next
+//! cancellation checkpoint. Cancellation is cooperative rather than immediate,
+//! so latency depends on the extractor and operation currently in progress.
+//!
 //! # FFI and bindings
 //!
 //! No binding exposes cancellation today. `crates/xberg-ffi` emits no
@@ -24,23 +32,23 @@
 //! so codegen can never emit one — any binding surface would have to be
 //! hand-written and hand-maintained.
 //!
-//! The token is driven entirely in-process: `cancel` and `is_cancelled` are
-//! `pub(crate)`, so even a downstream Rust crate can construct a token but
-//! cannot fire or observe it. The only live consumer is the REST job store
-//! (`crate::api::jobs::JobStore`), which registers a token per job and fires it
-//! from `DELETE /jobs/{job_id}`.
+//! Xberg also uses the same token internally for extraction timeouts and the
+//! REST async-job cancellation path (`DELETE /jobs/{job_id}`).
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// A lightweight, cloneable cancellation token.
+/// A lightweight, cloneable, one-shot cancellation token.
 ///
-/// Create one with `CancellationToken::default()`, pass clones to the extraction
-/// call (via `ExtractionConfig::cancel_token`) and to the caller. Call
-/// `cancel` from the caller side when the operation should be aborted.
-/// The extraction code polls `is_cancelled` at safe checkpoints and returns
-/// a cancellation error if set.
+/// Create one with `CancellationToken::default()`, pass one clone to extraction
+/// through `ExtractionConfig::cancel_token`, and retain another clone in the
+/// caller. Calling [`cancel`](Self::cancel) requests cooperative cancellation;
+/// extraction stops when it reaches an existing cancellation checkpoint.
+///
+/// A token cannot be reset. Once cancellation has been requested, all current
+/// and future clones continue to report that request. Create a new token for an
+/// unrelated extraction operation.
 ///
 /// Cloning is cheap (increments the `Arc` reference count only).
 #[cfg_attr(alef, alef(skip))]
@@ -56,25 +64,27 @@ impl CancellationToken {
         Self::default()
     }
 
-    /// Signal cancellation.
+    /// Request cooperative cancellation.
     ///
-    /// All clones of this token will observe [`is_cancelled`] returning `true`
-    /// on their next check. This operation is idempotent.
+    /// All clones of this token will observe [`is_cancelled`](Self::is_cancelled)
+    /// returning `true` on their next check. This operation is idempotent and
+    /// the token remains cancelled permanently.
     ///
-    /// Gated `not(target_arch = "wasm32")` to match the only call sites
-    /// (`run_timed_extraction` in `batch.rs`, the timeout block in `bytes.rs`):
-    /// `tokio-runtime` is enabled transitively on wasm32 via `layout-tract`
-    /// inside `wasm-target`, so gating on the feature alone leaves this method
-    /// compiled-but-uncalled (dead code) on that target.
-    #[cfg(any(all(feature = "tokio-runtime", not(target_arch = "wasm32")), test))]
+    /// This method does not forcibly interrupt the currently executing parser,
+    /// native call, or model invocation. Extraction stops when the active path
+    /// reaches an existing cancellation checkpoint, so no maximum cancellation
+    /// latency is implied.
     #[inline]
-    pub(crate) fn cancel(&self) {
+    pub fn cancel(&self) {
         self.cancelled.store(true, Ordering::Relaxed);
     }
 
-    /// Returns `true` if [`cancel`] has been called on any clone of this token.
+    /// Returns `true` if cancellation has been requested on any clone.
+    ///
+    /// This reports the token's request flag. It does not prove that a particular
+    /// extraction terminated because cancellation can race with normal completion.
     #[inline]
-    pub(crate) fn is_cancelled(&self) -> bool {
+    pub fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::Relaxed)
     }
 }

--- a/crates/xberg/src/core/config/extraction/core.rs
+++ b/crates/xberg/src/core/config/extraction/core.rs
@@ -431,17 +431,17 @@ pub struct ExtractionConfig {
     #[cfg_attr(feature = "alef-meta", alef(since = "1.0.0"))]
     pub qr_codes: Option<bool>,
 
-    /// Internal cancellation handle (None = no external cancellation).
+    /// Cooperative cancellation handle (`None` = no caller-initiated cancellation).
     ///
-    /// Set from two places, neither of them user-facing. The REST async-jobs code path
-    /// (`crate::api::jobs::JobStore`) registers a token per job and fires it from
-    /// `DELETE /jobs/{job_id}`. Otherwise [`Self::ensure_cancel_token`] installs an
-    /// internal one whenever `extraction_timeout_secs` is set, so the `token.cancel()`
-    /// call that accompanies every timeout has something to signal. There is no public
-    /// API, in any language binding, to construct or fire this token; it is not a
-    /// user-facing configuration value.
+    /// Rust callers may supply a [`crate::cancellation::CancellationToken`], retain a
+    /// clone, and call [`crate::cancellation::CancellationToken::cancel`] to request
+    /// that extraction stop at its next cancellation checkpoint. Cancellation is
+    /// cooperative rather than immediate, so latency depends on the extractor and
+    /// operation currently in progress.
     ///
-    /// The field is excluded from serialization for the same reason.
+    /// Xberg also installs and uses cancellation tokens internally for extraction
+    /// timeouts and REST async jobs. This field remains excluded from serialization
+    /// and Alef-generated language bindings.
     #[serde(skip)]
     #[cfg_attr(alef, alef(skip))]
     pub cancel_token: Option<crate::cancellation::CancellationToken>,
@@ -597,23 +597,23 @@ impl ExtractionConfig {
     /// caller supplied one.
     ///
     /// `extraction_timeout_secs` fires `token.cancel()` at every timeout call site
-    /// (`core/extractor/{file,bytes,batch}.rs`, `engine/extract_impl.rs`), but every
-    /// binding-driven and CLI-driven call leaves `cancel_token` `None` — only the
-    /// REST job store (`crate::api::jobs::JobStore`, wired in `api/handlers.rs`)
-    /// ever supplies one. Without this, `token.cancel()` has nothing to signal: the
-    /// timeout stops *waiting* and returns `XbergError::Timeout`, but the spawned
-    /// extraction work keeps running to completion, burning a thread.
+    /// (`core/extractor/{file,bytes,batch}.rs`, `engine/extract_impl.rs`). Binding-
+    /// driven and CLI-driven calls generally leave `cancel_token` as `None` unless
+    /// a Rust caller explicitly supplies one. Without this fallback, `token.cancel()`
+    /// has nothing to signal: the timeout stops *waiting* and returns
+    /// `XbergError::Timeout`, but spawned extraction work can continue running to
+    /// completion and consume a worker thread.
     ///
-    /// A caller-supplied token (the REST cancel path, `DELETE /jobs/{id}`) is
-    /// always left untouched, so it keeps working exactly as before.
+    /// A caller-supplied token is always left untouched, so Rust callers and the
+    /// REST cancellation path continue observing the same shared token.
     ///
-    /// No-op when `extraction_timeout_secs` is `None`: without a timeout nothing
-    /// can ever call `cancel()`, so installing a token would be dead weight.
+    /// No-op when `extraction_timeout_secs` is `None`: without an internal timeout
+    /// path there is no need to allocate a fallback token. Callers may still supply
+    /// their own token for explicit cancellation.
     ///
-    /// Unconditional on target/feature: [`crate::cancellation::CancellationToken`]'s
-    /// `Default` impl and this field are compiled on every target including
-    /// wasm32 — only [`crate::cancellation::CancellationToken::cancel`] itself is
-    /// gated to `not(wasm32)`, at the call sites that invoke it.
+    /// Unconditional on target/feature: the token and its atomic operations are
+    /// available on every target, including wasm32. Timeout call sites remain gated
+    /// independently where runtime support requires it.
     pub(crate) fn ensure_cancel_token(&mut self) {
         if self.extraction_timeout_secs.is_some() && self.cancel_token.is_none() {
             self.cancel_token = Some(crate::cancellation::CancellationToken::default());
@@ -978,8 +978,8 @@ mod tests {
     /// Regression test for task #709: without an internal fallback token, the
     /// `token.cancel()` calls at every `extraction_timeout_secs` call site
     /// (`core/extractor/{file,bytes,batch}.rs`, `engine/extract_impl.rs`) have nothing
-    /// to signal on any binding-driven or CLI-driven call, because `cancel_token` is
-    /// `None` there — only the REST job store ever supplies one.
+    /// to signal on calls that do not explicitly supply a token. A Rust caller or the
+    /// REST job store may provide one; other paths still require the internal fallback.
     #[test]
     fn ensure_cancel_token_installs_a_token_when_a_timeout_is_configured_and_none_was_supplied() {
         let mut config = ExtractionConfig {
@@ -994,9 +994,10 @@ mod tests {
         );
     }
 
-    /// A caller-supplied token (the REST cancel path, `DELETE /jobs/{id}`) must survive
-    /// unchanged — `ensure_cancel_token` must never replace it with a different token,
-    /// or the REST cancel handle would stop being the token extractors observe.
+    /// A caller-supplied token, whether retained by a Rust caller or the REST job
+    /// cancellation path, must survive unchanged. `ensure_cancel_token` must never
+    /// replace it with a different token or the retained handle would stop observing
+    /// the token extractors poll.
     #[test]
     fn ensure_cancel_token_preserves_a_caller_supplied_token() {
         let supplied = crate::cancellation::CancellationToken::new();
@@ -1015,8 +1016,8 @@ mod tests {
         );
     }
 
-    /// No timeout means nothing can ever call `cancel()`, so installing a token would be
-    /// dead weight; `cancel_token` must stay `None`.
+    /// Without a configured timeout, no internal timeout path needs an automatically
+    /// installed token. A caller may still supply its own explicit cancellation token.
     #[test]
     fn ensure_cancel_token_is_a_noop_without_a_configured_timeout() {
         let mut config = ExtractionConfig {
@@ -1027,7 +1028,7 @@ mod tests {
         config.ensure_cancel_token();
         assert!(
             config.cancel_token.is_none(),
-            "no timeout means no token is ever needed"
+            "no timeout means no internal fallback token is needed"
         );
     }
 

--- a/crates/xberg/src/error.rs
+++ b/crates/xberg/src/error.rs
@@ -228,9 +228,12 @@ pub enum XbergError {
         limit_ms: u64,
     },
 
-    /// The extraction was cancelled. Reachable today only via the REST async-jobs API
-    /// (`DELETE /jobs/{id}`); no binding exposes an in-process way to cancel an
-    /// extraction.
+    /// The extraction stopped after a cooperative cancellation request.
+    ///
+    /// Rust callers can request cancellation through
+    /// [`crate::cancellation::CancellationToken`]. The REST async-jobs API uses the
+    /// same mechanism. Generated language bindings do not currently expose
+    /// in-process cancellation.
     #[error("Extraction cancelled")]
     #[cfg_attr(alef, alef(error_code = 1015))]
     Cancelled,

--- a/crates/xberg/tests/cancellation_public_api.rs
+++ b/crates/xberg/tests/cancellation_public_api.rs
@@ -1,0 +1,33 @@
+use xberg::ExtractionConfig;
+use xberg::cancellation::CancellationToken;
+
+#[test]
+fn rust_callers_can_request_and_observe_cooperative_cancellation() {
+    let caller_token = CancellationToken::default();
+    let extraction_token = caller_token.clone();
+
+    let config = ExtractionConfig {
+        cancel_token: Some(extraction_token),
+        ..Default::default()
+    };
+
+    assert!(
+        !caller_token.is_cancelled(),
+        "a newly created token must not contain a cancellation request"
+    );
+
+    caller_token.cancel();
+
+    assert!(
+        caller_token.is_cancelled(),
+        "the caller's token must observe its cancellation request"
+    );
+    assert!(
+        config
+            .cancel_token
+            .as_ref()
+            .expect("the extraction config should retain its token")
+            .is_cancelled(),
+        "the token stored in ExtractionConfig must share the same cancellation state"
+    );
+}


### PR DESCRIPTION
## Related

Related to #1313, which uses Xberg's existing `CancellationToken` for REST async-job cancellation.

## Description

Expose Xberg's existing cooperative cancellation controls to downstream Rust applications.

`ExtractionConfig` already accepts a `CancellationToken`, but downstream Rust callers cannot currently signal or inspect it because `cancel()` and `is_cancelled()` are crate-private.

### Why this is useful for Rust embedders

This is useful beyond any one application because extraction is often embedded inside a longer-lived process that owns the lifecycle of the work. In those environments, simply dropping a future or no longer awaiting a result is not necessarily equivalent to stopping synchronous parser work, native calls, OCR/model work, or other extraction already in progress. The application needs a way to propagate its own cancellation decision into Xberg's existing cooperative cancellation path.

Examples include:

- desktop and mobile applications exposing a user-visible **Stop/Cancel** action;
- HTTP/RPC handlers propagating client disconnects or request cancellation into extraction;
- job queues withdrawing work that has been cancelled, superseded, or deprioritized;
- interactive applications replacing an in-progress extraction when the user chooses a newer document or configuration;
- services performing graceful shutdown without intentionally starting a second cancellation mechanism around Xberg;
- resource-constrained applications that need obsolete work to release worker capacity as soon as Xberg reaches an existing cancellation checkpoint.

Xberg already has the difficult part of this mechanism: a cloneable token is threaded through `ExtractionConfig`, extraction code polls it at established checkpoints, and timeouts / REST async jobs already use it. Exposing the two existing controls to Rust callers lets embedders participate in that same mechanism instead of requiring each application to invent a parallel cancellation abstraction or treat abandonment of the outer future as cancellation.

This keeps the proposal deliberately small: it makes an existing internal capability usable by Rust callers without adding new checkpoints, changing cancellation behavior, or creating a new controller/handle type.

### Changes

This PR:

- makes `CancellationToken::cancel()` public;
- makes `CancellationToken::is_cancelled()` public;
- makes `cancel()` available independently of `tokio-runtime` and native-target gating, including wasm32;
- documents cooperative latency, one-shot lifecycle, and completion races;
- documents `ExtractionConfig::cancel_token` as a supported Rust embedding hook;
- updates `XbergError::Cancelled` documentation;
- adds an integration test compiled as a downstream crate, proving that a retained clone can request cancellation and that the clone stored in `ExtractionConfig` observes the same state.

Cancellation remains cooperative rather than forceful: `cancel()` requests cancellation, and active work stops when it reaches an existing cancellation checkpoint. This PR does not add checkpoints, dependencies, or a second cancellation abstraction.

The token and `ExtractionConfig::cancel_token` remain excluded from Alef generation, so this does not add cancellation to generated language bindings.

### Validation

Passed locally after rebasing onto current `main`:

- `cargo test --locked -p xberg --no-default-features --test cancellation_public_api`
- `cargo test --locked -p xberg --test cancellation_public_api`
- `cargo test --locked -p xberg --no-default-features --lib cancellation::tests` — 5/5 passed
- `cargo check --locked -p xberg --no-default-features`
- `cargo check --locked -p xberg --no-default-features --features wasm-target --target wasm32-unknown-unknown`
- Clippy with `-D warnings` for the xberg library and new integration test under both minimal and default features
- focused `rustfmt --check` across all four modified files
- `cargo doc --locked -p xberg --no-deps --no-default-features`
- `cargo doc --locked -p xberg --no-deps`

Repository-wide checks currently expose unrelated baseline/environment issues outside this diff: existing formatting drift, an unrelated DOCX Clippy doc-list lint, an unrelated OCR doctest snippet, and the full-feature local Clippy build requires Xberg CI's custom libheif >=1.21 installation (Ubuntu 24.04 ships an older version).

## Checklist

- [ ] CI passing
- [x] Tests added where applicable
