### PR TITLE
fix(xml): clamp heading levels before narrowing to u8

### DIFF
--- a/crates/xberg/src/extractors/xml.rs
+++ b/crates/xberg/src/extractors/xml.rs
@@ -79,7 +79,7 @@ fn build_internal_document(content: &[u8], mime_type: &str, budget: &mut Securit
                     }
                 }
 
-                let level = ((depth as u8) + 1).min(6);
+                let level = depth.saturating_add(1).min(6) as u8;
                 let mut elem =
                     InternalElement::text(ElementKind::Heading { level }, &name_owned, depth).with_index(index);
                 if !attrs.is_empty() {
@@ -130,7 +130,7 @@ fn build_internal_document(content: &[u8], mime_type: &str, budget: &mut Securit
                     }
                 }
 
-                let level = ((depth as u8) + 1).min(6);
+                let level = depth.saturating_add(1).min(6) as u8;
                 let mut elem = InternalElement::text(ElementKind::Heading { level }, &name, depth).with_index(index);
                 if !attrs.is_empty() {
                     elem = elem.with_attributes(attrs);
@@ -316,6 +316,43 @@ mod tests {
         assert_eq!(xml_meta.element_count, 3);
         assert!(xml_meta.unique_elements.contains(&"root".to_string()));
         assert!(xml_meta.unique_elements.contains(&"item".to_string()));
+    }
+
+    /// `depth` is a `u16` and the heading level a `u8`, so casting before the `min(6)`
+    /// overflowed at depth 255: a panic in debug, a wrapped level 0 in release. The default
+    /// `max_nesting_depth` is 1024, so that depth is reachable by a valid document.
+    #[test]
+    fn should_clamp_heading_levels_for_xml_nested_past_the_u8_boundary() {
+        const DEPTH: usize = 300;
+        let mut content = String::new();
+        for i in 0..DEPTH {
+            content.push_str(&format!("<e{i}>"));
+        }
+        content.push_str("leaf");
+        for i in (0..DEPTH).rev() {
+            content.push_str(&format!("</e{i}>"));
+        }
+
+        let config = ExtractionConfig::default();
+        let mut budget = SecurityBudget::from_config(&config);
+        let doc = build_internal_document(content.as_bytes(), "application/xml", &mut budget)
+            .expect("a document within max_nesting_depth must extract");
+
+        let levels: Vec<u8> = doc
+            .elements
+            .iter()
+            .filter_map(|element| match element.kind {
+                ElementKind::Heading { level } => Some(level),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(levels.len(), DEPTH, "every element should yield a heading");
+        assert!(
+            levels.iter().all(|level| (1..=6).contains(level)),
+            "heading levels must stay within 1..=6, saw {:?}",
+            levels.iter().collect::<std::collections::BTreeSet<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Related

Closes #1474

## Description

`build_internal_document` computed the heading level as `((depth as u8) + 1).min(6)` in both the
start-element and empty-element paths. `depth` is a `u16` and the level a `u8`, so the narrowing ran
before the clamp. At depth 255 the addition overflows: debug builds panic, release builds wrap to
level 0, which renders as `<h0>` in HTML and as no heading marker at all in Markdown.

Nothing rejects the document first. `max_nesting_depth` defaults to 1024, so a valid document
reaches depth 255 long before the security limit has anything to say.

The fix clamps in `u16` and narrows afterwards:

```rust
let level = depth.saturating_add(1).min(6) as u8;
```

`saturating_add` rather than `+` so the top of the `u16` range does not trade one overflow for
another. Both call sites change identically.

## Checklist

- [x] CI passing
- [x] Tests added where applicable

`should_clamp_heading_levels_for_xml_nested_past_the_u8_boundary` builds a 300-deep document,
asserts every element yields a heading and that every level lands in `1..=6`. It calls
`build_internal_document` directly, so it needs no fixture and no corpus.

Reverting the fix and keeping the test reproduces the reported failure exactly:

```
panicked at crates/xberg/src/extractors/xml.rs:82:29:
attempt to add with overflow
```

`cargo clippy --locked -p xberg --features full --all-targets -- -D warnings` exits 0 and
`cargo fmt -p xberg -- --check` is clean. `cargo test --locked -p xberg --features full --lib` is
7343 passed with one unrelated failure,
`core::pipeline::issue_213_chunk_offset_ordering_tests::chunk_offsets_index_the_final_normalized_content`,
which fails with `Other("Processor cache not initialized")` and passes on its own. It looks
order-dependent rather than related to this change: a full run earlier today on a different branch
had it green and instead failed
`engine::extract_impl::tests::extract_py_local_uri_returns_source_code_mime`, which downloads a
tree-sitter grammar at runtime. Happy to file that separately if it is not already known.
