### PR TITLE
feat(tesseract): allow linking the host Tesseract with no network access

### DIFF
--- a/crates/xberg-tesseract/Cargo.toml
+++ b/crates/xberg-tesseract/Cargo.toml
@@ -33,6 +33,16 @@ build-tesseract-wasm = ["cmake", "reqwest", "zip"]
 bundle-tessdata-eng = []
 static-linking = ["build-tesseract"]
 dynamic-linking = []
+# Link the host's Tesseract and Leptonica instead of downloading and building vendored copies,
+# for a build with no network access such as a conda-forge recipe or a distro package.
+#
+# `build-tesseract` is included because it gates the FFI declarations, not because anything is
+# built: `main` in build.rs gives `dynamic-linking` precedence and skips the vendored path. The
+# gating is why `dynamic-linking` cannot stand alone today -- without `build-tesseract` the
+# extern blocks vanish and the crate fails to compile. Untangling that spans 38 sites across six
+# cfg shapes, including inverted ones selecting stub implementations, so it is left as separate
+# work rather than folded in here. ~keep
+system-linking = ["build-tesseract", "dynamic-linking"]
 
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/xberg-tesseract/build.rs
+++ b/crates/xberg-tesseract/build.rs
@@ -1873,12 +1873,21 @@ Installation instructions:
 }
 
 fn main() {
-    #[cfg(any(feature = "build-tesseract", feature = "build-tesseract-wasm"))]
+    // `dynamic-linking` is an explicit opt out of the vendored build, so it outranks the
+    // default `build-tesseract` rather than being ignored beside it. Cargo features are
+    // additive and a dependent cannot switch off a dependency's defaults, so precedence here
+    // is the only way a network-isolated build -- a conda-forge recipe, a distro package --
+    // can ask for the system libraries. `build-tesseract-wasm` still wins: that target has no
+    // system Tesseract to link against. ~keep
+    #[cfg(any(
+        feature = "build-tesseract-wasm",
+        all(feature = "build-tesseract", not(feature = "dynamic-linking"))
+    ))]
     {
         build_tesseract::build();
     }
 
-    #[cfg(all(feature = "dynamic-linking", not(feature = "build-tesseract")))]
+    #[cfg(all(feature = "dynamic-linking", not(feature = "build-tesseract-wasm")))]
     {
         eprintln!("Using dynamic linking with system-installed Tesseract libraries");
         println!("cargo:rustc-link-lib=dylib=tesseract");

--- a/crates/xberg/Cargo.toml
+++ b/crates/xberg/Cargo.toml
@@ -164,6 +164,12 @@ ocr = [
 # so the runtime tessdata resolver can materialize English OCR offline without a
 # network download. Forwarded to xberg-tesseract.
 bundle-tessdata-eng = ["xberg-tesseract/bundle-tessdata-eng"]
+# Link the host's Tesseract and Leptonica instead of downloading and building vendored copies.
+# The vendored path fetches sources over the network at build time, so it cannot run in a
+# network-isolated build such as a conda-forge recipe or a distro package. Additive: it takes
+# precedence inside xberg-tesseract's build script rather than needing the default switched off,
+# which a dependent cannot do. Forwarded to xberg-tesseract.
+tesseract-dynamic = ["xberg-tesseract?/system-linking"]
 # WASM OCR: Minimal Tesseract backend without html-to-markdown (which has WASI imports)
 # Includes only the core OCR processing dependencies needed for Tesseract on WASM
 ocr-wasm = [


### PR DESCRIPTION
## Related

Refs #1407. This is the precondition for conda packaging rather than the packaging itself, so it
does not close the issue.

## Description

There is currently no configuration in which `xberg` can be built without downloading Tesseract.

`crates/xberg/Cargo.toml` declares `xberg-tesseract = { path = "../xberg-tesseract", optional =
true }`, so with default features. `xberg-tesseract` defaults to `static-linking`, which pulls
`build-tesseract`, which fetches Leptonica 1.87.0 and Tesseract 5.5.3 over the network and builds
them with CMake. Cargo gives a dependent no way to switch a dependency's default features off, so
the download is unavoidable from outside the crate.

That rules out every network-isolated build: a conda-forge recipe, a distro package, air-gapped CI.

`dynamic-linking` already emitted exactly what such a build needs, two dylib link directives and
nothing else, but it was unreachable. The build script gated it on `not(feature =
"build-tesseract")`, a condition no dependent could arrange, because `build-tesseract` arrives
through the default.

### The change

Three pieces, 28 lines.

1. **`dynamic-linking` now takes precedence over `build-tesseract`** in `build.rs` `main`, rather
   than being ignored beside it. Enabling it is therefore sufficient, with no need to unset a
   default. `build-tesseract-wasm` still wins, since that target has no system Tesseract to link.
2. **`system-linking = ["build-tesseract", "dynamic-linking"]`** in `xberg-tesseract`.
   `dynamic-linking` cannot stand alone yet: without `build-tesseract` the FFI extern blocks are
   cfg'd out and the crate does not compile. The feature composes the two and the comment says
   plainly why.
3. **`tesseract-dynamic = ["xberg-tesseract?/system-linking"]`** on `xberg`, alongside the existing
   `bundle-tessdata-eng` passthrough.

Additive throughout, so nothing changes for an existing build.

### Deliberately not done

Widening the cfg gating so `dynamic-linking` stands alone. That spans 38 mentions of
`build-tesseract` across six distinct cfg shapes in `xberg-tesseract/src`, including inverted ones
that select stub implementations. It is a rework of the crate's conditional-compilation strategy,
not a packaging enabler, and it did not belong in the same change. Noted in the code comment as
separate work, and happy to open an issue for it.

## Checklist

- [x] CI passing
- [x] Tests added where applicable

No new tests: the change is feature plumbing with no new runtime behaviour, and the existing suite
covers the OCR paths on both linking modes. What I verified by hand instead:

| check | result |
|---|---|
| `cargo build -p xberg-tesseract --no-default-features --features dynamic-linking -vv` | build script logs `Using dynamic linking with system-installed Tesseract libraries`, emits only `cargo:rustc-link-lib=dylib=tesseract` and `=leptonica`, and runs no download and no CMake |
| `cargo check -p xberg --no-default-features --features "ocr,tesseract-dynamic"` | clean, vendored path skipped |
| `cargo check -p xberg --no-default-features --features "ocr"` | clean, still reports `Linking with tesseract (static linking)` |
| `cargo clippy --locked -p xberg --features full --all-targets -- -D warnings` | 0 errors |
| `cargo test --locked -p xberg --features full --lib` | 7343 passed, 0 failed |

Two limits worth stating. The final **link** is unverified locally, because this machine has no
system libtesseract and installing one seemed worse than saying so: the compile-and-emit behaviour
is what I could prove, and the link is what a conda environment supplies. And I did not build the
wasm leg. Its gate is preserved by construction, `build-tesseract-wasm` stays first in the `any(...)`
and the dynamic arm excludes it, but CI's wasm-target leg is the real check.

## Why this helps #1407

With this in place the remaining conda work is a recipe in `conda-forge/staged-recipes`, and the
scoping looks better than the issue assumed:

- **Every native dependency already has a conda-forge feedstock.** tesseract 5.5.3 and leptonica
  1.87.0 are the exact versions vendored here; libheif is at **1.23.1**, newer than the 1.23.0 built
  from source in CI. The reporter's original break was an out-of-date system libheif, so the conda
  ecosystem resolves it by existing.
- **PyPI already publishes an sdist** for `xberg`, the standard conda-forge source for a maturin
  project, so no new release artifact is needed.
- **ONNX Runtime is already handled.** `publish.yaml` and `ci-python-wheel-smoke.yaml` build with
  `ORT_STRATEGY=system ORT_SKIP_DOWNLOAD=1 ORT_PREFER_DYNAMIC_LINK=1`; a recipe does the same
  against conda's `onnxruntime`.

On the alef question from 2026-08-08: this was Cargo feature plumbing rather than anything
generated, and a recipe lives in `staged-recipes`, so alef is not involved either way.
