### PR TITLE
fix(epub): stop dropping chapters, metadata and whole books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- EPUB chapters that use HTML named entities such as `&nbsp;` next to a `style` or `script`
+  substring in any tag are extracted again. The entities are expanded before the XML parse, a
+  leading byte order mark no longer defeats the prelude stripper, and a chapter that is still not
+  well-formed XML now emits a warning that names the file instead of vanishing silently (#1488).
+- EPUB navigation documents are identified from the package (`properties="nav"` and the EPUB 2
+  guide `toc` reference) instead of a link-count heuristic, so bibliographies, endnotes, licence
+  pages and chapter overview pages stay in plain-text output. Image-only spine pages such as covers,
+  plates and fixed-layout pages now reach the image pipeline, and SVG spine documents render their
+  text (#1489).
+- A deeply nested EPUB chapter no longer overflows the stack and ends the process; the text walks
+  stop at the configured XML depth limit (#1490).
+- One EPUB spine item with an unsafe manifest href no longer fails the whole book; it is skipped with
+  a warning. Markdown conversion warnings are now reported, and a warning names the skipped items
+  when the iteration limit stops the spine loop (#1491).
+- EPUB metadata keeps every creator as an author and every subject as a keyword, keeps the main
+  title instead of the last one, prefers the publication date over the modification date, and finds
+  EPUB 3 `cover-image` covers while ignoring cover references that point at an XHTML page (#1492).
+- EPUB rendering keeps the rows of a table that contains a nested table, removes the line-break
+  sentinel from headings that contain `<br>`, strips the serialised MathML comment from Markdown
+  output, and renders the alt text of an image that cannot be resolved (#1493).
+- EPUB members declared in a non-UTF-8 encoding or written in UTF-16 are decoded instead of skipped,
+  and books with DRM listed in `META-INF/encryption.xml` report one warning instead of blaming the
+  encoding or emitting ciphertext as text (#1494).
 - Benchmark Tesseract cache isolation now preserves automatic page-segmentation and sparse-image
   fallback behavior, preventing valid receipt OCR from being reclassified as zero-overlap output.
 - Windows Ruby gem builds now keep MSVC-only C++ flags out of the MinGW toolchain when compiling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11820,6 +11820,7 @@ dependencies = [
  "hayro-jpeg2000",
  "hex",
  "hf-hub",
+ "html-escape",
  "html-to-markdown-rs",
  "icu_provider",
  "icu_segmenter",

--- a/crates/xberg/Cargo.toml
+++ b/crates/xberg/Cargo.toml
@@ -94,6 +94,7 @@ office = [
     "dep:dbase",
     "dep:typst-syntax",
     "dep:mathemascii",
+    "dep:html-escape",
     "html",
     "notebook",
 ]
@@ -1261,6 +1262,7 @@ flate2 = { version = "1.1", optional = true }
 hayro-jbig2 = { version = "0.3", default-features = false, features = ["std"], optional = true }
 hayro-jpeg2000 = { version = "0.4", default-features = false, features = ["std", "simd"], optional = true }
 hex = { workspace = true }
+html-escape = { version = "0.2.15", optional = true }
 html-to-markdown-rs = { workspace = true, features = ["inline-images", "metadata"], optional = true }
 icu_provider = { version = "2", features = ["sync"], optional = true }
 icu_segmenter = { version = "2", optional = true }

--- a/crates/xberg/src/extraction/html/structure.rs
+++ b/crates/xberg/src/extraction/html/structure.rs
@@ -174,6 +174,10 @@ struct HtmlWalker<'a, 'b> {
     in_pre: bool,
     pre_block: Option<PreBlock>,
     table: Option<TableAccumulator>,
+    /// Number of `<table>` elements open inside the accumulated table. A nested
+    /// table is flattened into the enclosing cell instead of replacing the
+    /// enclosing table.
+    nested_table_depth: usize,
     list_stack: Vec<ListContext>,
     in_list_item: bool,
     list_item_text: String,
@@ -201,6 +205,7 @@ impl<'a, 'b> HtmlWalker<'a, 'b> {
             in_pre: false,
             pre_block: None,
             table: None,
+            nested_table_depth: 0,
             list_stack: Vec::new(),
             in_list_item: false,
             list_item_text: String::new(),
@@ -415,14 +420,25 @@ impl<'a, 'b> HtmlWalker<'a, 'b> {
                 }
             }
             "table" => {
-                self.flush_paragraph();
-                self.table = Some(TableAccumulator::new());
+                if let Some(ref mut table) = self.table {
+                    self.nested_table_depth += 1;
+                    table.push_text(" ");
+                } else {
+                    self.flush_paragraph();
+                    self.table = Some(TableAccumulator::new());
+                }
             }
             "tr" | "thead" | "tbody" | "tfoot" => {
                 if tag == "tr"
+                    && self.nested_table_depth == 0
                     && let Some(ref mut table) = self.table
                 {
                     table.open_row();
+                }
+            }
+            "th" | "td" if self.nested_table_depth > 0 => {
+                if let Some(ref mut table) = self.table {
+                    table.push_text(" ");
                 }
             }
             "th" | "td" => {
@@ -574,7 +590,7 @@ impl<'a, 'b> HtmlWalker<'a, 'b> {
         match tag {
             "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
                 let level: u8 = tag[1..].parse().unwrap_or(1);
-                let text = self.text_buf.trim().to_string();
+                let text = normalize_whitespace(&self.text_buf).trim().to_string();
                 if !text.is_empty() {
                     let idx = self.builder.push_heading(level, &text, None, None);
                     if let Some(classes) = self.pending_classes.take() {
@@ -634,6 +650,9 @@ impl<'a, 'b> HtmlWalker<'a, 'b> {
                     ctx.item_open = false;
                 }
             }
+            "table" if self.nested_table_depth > 0 => {
+                self.nested_table_depth -= 1;
+            }
             "table" => {
                 if let Some(mut table) = self.table.take() {
                     table.close_cell();
@@ -643,6 +662,7 @@ impl<'a, 'b> HtmlWalker<'a, 'b> {
                     }
                 }
             }
+            "tr" | "th" | "td" if self.nested_table_depth > 0 => {}
             "tr" => {
                 if let Some(ref mut table) = self.table {
                     table.close_cell();
@@ -1602,6 +1622,44 @@ mod tests {
             }
             other => panic!("Expected Table, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_nested_table_is_flattened_into_the_enclosing_cell() {
+        let html = "<table><tr><td>A1</td><td>A2</td></tr><tr><td><table><tr><td>N1</td><td>N2</td></tr></table></td><td>B2</td></tr><tr><td>C1</td><td>C2</td></tr></table>";
+        let doc = build_document_structure(html);
+        assert!(doc.validate().is_ok());
+        assert_eq!(doc.nodes.len(), 1, "got {:?}", doc.nodes);
+        match &doc.nodes[0].content {
+            NodeContent::Table { grid } => {
+                assert_eq!(grid.rows, 3);
+                assert_eq!(grid.cols, 2);
+                let texts: Vec<&str> = grid.cells.iter().map(|c| c.content.as_str()).collect();
+                assert!(texts.contains(&"A1"), "got {texts:?}");
+                assert!(texts.contains(&"C2"), "got {texts:?}");
+                assert!(
+                    texts.iter().any(|t| t.contains("N1") && t.contains("N2")),
+                    "got {texts:?}"
+                );
+            }
+            other => panic!("Expected Table, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_heading_line_breaks_become_newlines_without_sentinels() {
+        let html = "<h2><br/><br/>CHAPTER I.</h2><h1>PRIDE<br/>and<br/>PREJUDICE</h1>";
+        let doc = build_document_structure(html);
+        let headings: Vec<String> = doc
+            .nodes
+            .iter()
+            .filter_map(|node| match &node.content {
+                NodeContent::Heading { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(headings, vec!["CHAPTER I.", "PRIDE\nand\nPREJUDICE"]);
+        assert!(headings.iter().all(|h| !h.contains('\x01')));
     }
 
     #[test]

--- a/crates/xberg/src/extractors/epub/content.rs
+++ b/crates/xberg/src/extractors/epub/content.rs
@@ -99,7 +99,17 @@ pub(super) fn read_body_documents(
                     continue;
                 }
 
-                if extract_text_from_xhtml(&render_xhtml).is_empty() {
+                let (text, parse_error) = extract_text_from_xhtml_reporting(&render_xhtml);
+                if let Some(error) = parse_error {
+                    warnings.push(ProcessingWarning {
+                        source: std::borrow::Cow::Borrowed("epub"),
+                        message: std::borrow::Cow::Owned(format!(
+                            "Spine item '{}' is not well-formed XML ({}); its text was recovered by stripping tags",
+                            file_path, error
+                        )),
+                    });
+                }
+                if text.is_empty() {
                     continue;
                 }
 
@@ -387,6 +397,14 @@ const SKIP_ELEMENTS: &[&str] = &["head", "script", "style", "video", "audio", "s
 /// pure drawing geometry with no meaningful text of its own.
 const SVG_TEXT_ELEMENTS: &[&str] = &["title", "desc", "text", "tspan", "textpath"];
 
+/// Element depth at which the recursive text walks stop descending.
+///
+/// `roxmltree` builds its tree without recursion, so a chapter nested tens of
+/// thousands of elements deep parses fine and then overflows the stack in the
+/// walks below. The unbudgeted walk uses this constant; the budgeted walk uses
+/// `SecurityBudget::enter`, whose default limit is the same value.
+const MAX_WALK_DEPTH: usize = 1024;
+
 /// Walk an `<svg>` subtree, extracting text only from [`SVG_TEXT_ELEMENTS`] descendants.
 ///
 /// Unlike the generic block-element walk, this never emits text from arbitrary elements —
@@ -398,7 +416,11 @@ fn visit_svg_node(
     output: &mut String,
     in_text_context: bool,
     budget: Option<&mut SecurityBudget>,
+    depth: usize,
 ) {
+    if depth > MAX_WALK_DEPTH {
+        return;
+    }
     let mut budget = budget;
     match node.node_type() {
         roxmltree::NodeType::Text if in_text_context => {
@@ -435,7 +457,7 @@ fn visit_svg_node(
                 output.push('\n');
             }
             for child in node.children() {
-                visit_svg_node(child, output, child_in_text_context, budget.as_deref_mut());
+                visit_svg_node(child, output, child_in_text_context, budget.as_deref_mut(), depth + 1);
             }
             if entering_text_tag && !output.is_empty() && !output.ends_with('\n') {
                 output.push('\n');
@@ -477,62 +499,42 @@ fn render_math_element(node: roxmltree::Node<'_, '_>, output: &mut String, budge
 ///
 /// When `budget` is provided, entity and growth limits are enforced during traversal.
 pub(super) fn extract_text_from_xhtml(xhtml: &str) -> String {
+    extract_text_from_xhtml_with_budget(xhtml, None).0
+}
+
+/// Like [`extract_text_from_xhtml`], but also returns the XML parse error when
+/// the chapter is not well-formed and the text came from the tag stripper.
+pub(super) fn extract_text_from_xhtml_reporting(xhtml: &str) -> (String, Option<String>) {
     extract_text_from_xhtml_with_budget(xhtml, None)
 }
 
 pub(super) fn extract_text_from_xhtml_budgeted(xhtml: &str, budget: &mut SecurityBudget) -> String {
-    extract_text_from_xhtml_with_budget(xhtml, Some(budget))
+    extract_text_from_xhtml_with_budget(xhtml, Some(budget)).0
 }
 
-fn extract_text_from_xhtml_with_budget(xhtml: &str, budget: Option<&mut SecurityBudget>) -> String {
-    let result = match budget {
-        Some(b) => try_extract_via_roxmltree_budgeted(xhtml, b),
-        None => try_extract_via_roxmltree_unbounded(xhtml),
+/// Walk the parsed chapter and collect its text. When `budget` is given, entity
+/// and growth violations stop the walk early and the partial output is kept.
+/// When the chapter is not well-formed XML, or the walk yields no text, the
+/// tag stripper runs instead. The second value is the parse error, if any.
+fn extract_text_from_xhtml_with_budget(xhtml: &str, budget: Option<&mut SecurityBudget>) -> (String, Option<String>) {
+    let sanitized = normalize_xhtml(xhtml);
+
+    let parsed = match roxmltree::Document::parse(&sanitized) {
+        Ok(doc) => {
+            let mut output = String::with_capacity(xhtml.len() / 2);
+            match budget {
+                Some(budget) => visit_node_budgeted(doc.root(), &mut output, budget),
+                None => visit_node_unbounded(doc.root(), &mut output, 0),
+            }
+            Ok(collapse_blank_lines(&output).trim().to_string())
+        }
+        Err(err) => Err(err.to_string()),
     };
-    if let Some(text) = result {
-        return text;
-    }
 
-    let normalized = normalize_xhtml(xhtml);
-    strip_html_tags(&normalized)
-}
-
-/// Attempt to extract plain text via `roxmltree` XML parsing (no security budget).
-///
-/// Returns `None` if the document cannot be parsed as XML/XHTML.
-fn try_extract_via_roxmltree_unbounded(xhtml: &str) -> Option<String> {
-    let sanitized = normalize_xhtml(xhtml);
-
-    match roxmltree::Document::parse(&sanitized) {
-        Ok(doc) => {
-            let root = doc.root();
-            let mut output = String::with_capacity(xhtml.len() / 2);
-            visit_node_unbounded(root, &mut output);
-            let result = collapse_blank_lines(&output);
-            let result = result.trim().to_string();
-            if result.is_empty() { None } else { Some(result) }
-        }
-        Err(_) => None,
-    }
-}
-
-/// Attempt to extract plain text via `roxmltree` XML parsing with a security budget.
-///
-/// Entity and growth violations stop traversal early; partial output is returned.
-/// Returns `None` if the document cannot be parsed as XML/XHTML.
-fn try_extract_via_roxmltree_budgeted(xhtml: &str, budget: &mut SecurityBudget) -> Option<String> {
-    let sanitized = normalize_xhtml(xhtml);
-
-    match roxmltree::Document::parse(&sanitized) {
-        Ok(doc) => {
-            let root = doc.root();
-            let mut output = String::with_capacity(xhtml.len() / 2);
-            visit_node_budgeted(root, &mut output, budget);
-            let result = collapse_blank_lines(&output);
-            let result = result.trim().to_string();
-            if result.is_empty() { None } else { Some(result) }
-        }
-        Err(_) => None,
+    match parsed {
+        Ok(text) if !text.is_empty() => (text, None),
+        Ok(_) => (strip_html_tags(&sanitized), None),
+        Err(err) => (strip_html_tags(&sanitized), Some(err)),
     }
 }
 
@@ -542,7 +544,51 @@ fn try_extract_via_roxmltree_budgeted(xhtml: &str, budget: &mut SecurityBudget) 
 /// This strips XML declarations and doctypes, which are valid in EPUB chapter
 /// files but should not surface in extracted Markdown or interfere with safe parsing.
 pub(super) fn normalize_xhtml(xml: &str) -> String {
-    strip_serialized_mathml_comments(&strip_xml_prelude(xml))
+    expand_named_entities(&strip_serialized_mathml_comments(&strip_xml_prelude(xml)))
+}
+
+/// Replace HTML named character references that XML does not predefine.
+///
+/// XHTML 1.1 declares `&nbsp;`, `&mdash;`, `&eacute;` and the other HTML
+/// entities in its external DTD. The prelude stripper removes the DOCTYPE and
+/// `roxmltree` resolves no external entities, so one such reference makes the
+/// whole chapter unparseable. Each known reference becomes its character before
+/// parsing. The five XML references stay as written, and unknown references are
+/// left in place so the parser reports them.
+pub(super) fn expand_named_entities(xhtml: &str) -> String {
+    if !xhtml.contains('&') {
+        return xhtml.to_string();
+    }
+
+    let mut output = String::with_capacity(xhtml.len());
+    let mut rest = xhtml;
+    while let Some(start) = rest.find('&') {
+        output.push_str(&rest[..start]);
+        let candidate = &rest[start..];
+        let name_len = candidate[1..]
+            .bytes()
+            .take_while(|byte| byte.is_ascii_alphanumeric())
+            .count();
+        let replacement = (name_len > 0 && candidate.as_bytes().get(name_len + 1) == Some(&b';'))
+            .then(|| &candidate[..name_len + 2])
+            .filter(|reference| !matches!(*reference, "&amp;" | "&lt;" | "&gt;" | "&quot;" | "&apos;"))
+            .and_then(|reference| {
+                let decoded = html_escape::decode_html_entities(reference);
+                (decoded != reference).then(|| (decoded.into_owned(), reference.len()))
+            });
+        match replacement {
+            Some((decoded, consumed)) => {
+                output.push_str(&decoded);
+                rest = &candidate[consumed..];
+            }
+            None => {
+                output.push('&');
+                rest = &candidate[1..];
+            }
+        }
+    }
+    output.push_str(rest);
+    output
 }
 
 /// Some EPUB fixtures carry a readable MathML fallback immediately after a
@@ -577,7 +623,7 @@ fn strip_serialized_mathml_comments(xhtml: &str) -> String {
 /// EPUB chapter files often begin with an XML declaration followed by a DOCTYPE.
 /// Those are packaging details, not body content, and `roxmltree` rejects DTDs.
 fn strip_xml_prelude(xml: &str) -> String {
-    let mut rest = xml.trim_start();
+    let mut rest = xml.trim_start_matches('\u{FEFF}').trim_start();
 
     loop {
         if let Some(tail) = rest.strip_prefix("<?xml")
@@ -616,7 +662,10 @@ fn find_doctype_end(tail: &str) -> Option<usize> {
 }
 
 /// Recursively visit an XML node and append its text to `output` (no security budget).
-fn visit_node_unbounded(node: roxmltree::Node<'_, '_>, output: &mut String) {
+fn visit_node_unbounded(node: roxmltree::Node<'_, '_>, output: &mut String, depth: usize) {
+    if depth > MAX_WALK_DEPTH {
+        return;
+    }
     match node.node_type() {
         roxmltree::NodeType::Text => {
             let text = node.text().unwrap_or("");
@@ -645,7 +694,7 @@ fn visit_node_unbounded(node: roxmltree::Node<'_, '_>, output: &mut String) {
             // `<title>`/`<desc>` alt-text along with the (harmless to lose) drawing
             // geometry. Walk it selectively instead of skipping outright.
             if tag == "svg" {
-                visit_svg_node(node, output, false, None);
+                visit_svg_node(node, output, false, None, depth + 1);
                 return;
             }
             if SKIP_ELEMENTS.iter().any(|&s| s == tag) {
@@ -666,7 +715,7 @@ fn visit_node_unbounded(node: roxmltree::Node<'_, '_>, output: &mut String) {
                 output.push('\n');
             }
             for child in node.children() {
-                visit_node_unbounded(child, output);
+                visit_node_unbounded(child, output, depth + 1);
             }
             if is_block && !output.is_empty() && !output.ends_with('\n') {
                 output.push('\n');
@@ -674,7 +723,7 @@ fn visit_node_unbounded(node: roxmltree::Node<'_, '_>, output: &mut String) {
         }
         roxmltree::NodeType::Root => {
             for child in node.children() {
-                visit_node_unbounded(child, output);
+                visit_node_unbounded(child, output, depth + 1);
             }
         }
         _ => {}
@@ -713,7 +762,7 @@ fn visit_node_budgeted(node: roxmltree::Node<'_, '_>, output: &mut String, budge
                 return;
             }
             if tag == "svg" {
-                visit_svg_node(node, output, false, Some(budget));
+                visit_svg_node(node, output, false, Some(budget), 0);
                 return;
             }
             if SKIP_ELEMENTS.iter().any(|&s| s == tag) {
@@ -733,9 +782,13 @@ fn visit_node_budgeted(node: roxmltree::Node<'_, '_>, output: &mut String, budge
             if is_block && !output.is_empty() && !output.ends_with('\n') {
                 output.push('\n');
             }
+            if budget.enter().is_err() {
+                return;
+            }
             for child in node.children() {
                 visit_node_budgeted(child, output, budget);
             }
+            budget.leave();
             if is_block && !output.is_empty() && !output.ends_with('\n') {
                 output.push('\n');
             }
@@ -790,7 +843,8 @@ fn collapse_blank_lines(text: &str) -> String {
     result
 }
 
-/// Fallback: strip HTML tags without using specialized libraries
+/// Fallback for chapters that are not well-formed XML: strip tags, skip
+/// `<script>`/`<style>` bodies, and decode character references.
 pub(super) fn strip_html_tags(html: &str) -> String {
     let mut text = String::new();
     let mut in_tag = false;
@@ -807,9 +861,15 @@ pub(super) fn strip_html_tags(html: &str) -> String {
         if ch == '>' {
             in_tag = false;
 
-            let tag_lower = tag_name.to_lowercase();
-            if tag_lower.contains("script") || tag_lower.contains("style") {
-                in_script_style = !tag_name.starts_with('/');
+            let is_closing = tag_name.starts_with('/');
+            let name = tag_name
+                .trim_start_matches('/')
+                .split(|c: char| c.is_ascii_whitespace() || c == '/')
+                .next()
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            if name == "script" || name == "style" {
+                in_script_style = !is_closing;
             }
             continue;
         }
@@ -846,7 +906,7 @@ pub(super) fn strip_html_tags(html: &str) -> String {
         }
     }
 
-    result.trim().to_string()
+    html_escape::decode_html_entities(result.trim()).into_owned()
 }
 
 #[cfg(test)]
@@ -1118,5 +1178,84 @@ mod tests {
 
         let input2 = "a\n\nb";
         assert_eq!(collapse_blank_lines(input2), "a\n\nb");
+    }
+
+    #[test]
+    fn test_expand_named_entities_replaces_html_references_and_keeps_xml_ones() {
+        let xhtml = "<p>A&nbsp;B &mdash; C &amp; D &lt;E&gt; &#169; &unknown; &</p>";
+        let expanded = expand_named_entities(xhtml);
+        assert_eq!(
+            expanded,
+            "<p>A\u{a0}B \u{2014} C &amp; D &lt;E&gt; &#169; &unknown; &</p>"
+        );
+    }
+
+    #[test]
+    fn test_extract_text_from_xhtml_with_html_entities_keeps_structure() {
+        let xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><link rel="stylesheet" href="s.css"/><title></title></head>
+  <body>
+    <p style="text-indent:0">First&nbsp;para</p>
+    <p>Second &eacute;</p>
+  </body>
+</html>"#;
+        let result = extract_text_from_xhtml(xhtml);
+        assert_eq!(result, "First\u{a0}para\nSecond \u{e9}", "got: {result}");
+    }
+
+    #[test]
+    fn test_strip_xml_prelude_removes_a_byte_order_mark() {
+        let xhtml = "\u{FEFF}<?xml version=\"1.0\"?><!DOCTYPE html><html><body><p>Bom body</p></body></html>";
+        let result = extract_text_from_xhtml(xhtml);
+        assert_eq!(result, "Bom body", "got: {result}");
+    }
+
+    #[test]
+    fn test_strip_html_tags_only_skips_real_script_and_style_elements() {
+        let html = r#"<body><link rel="stylesheet" href="s.css"/><p style="x">Keep &amp; <span class="subscript">this</span></p> <noscript>also</noscript> <style>p{}</style> <p>end</p>"#;
+        let text = strip_html_tags(html);
+        assert_eq!(text, "Keep & this also end", "got: {text}");
+    }
+
+    #[test]
+    fn test_deeply_nested_xhtml_does_not_overflow_the_stack() {
+        let depth = 50_000;
+        let mut xhtml = String::from("<html><body><p>lead</p>");
+        for _ in 0..depth {
+            xhtml.push_str("<span>");
+        }
+        xhtml.push_str("deep");
+        for _ in 0..depth {
+            xhtml.push_str("</span>");
+        }
+        xhtml.push_str("<p>tail</p></body></html>");
+
+        let text = extract_text_from_xhtml(&xhtml);
+        assert!(text.contains("lead"), "got: {text}");
+        assert!(text.contains("tail"), "got: {text}");
+
+        let mut budget = SecurityBudget::from_limits(&crate::extractors::security::SecurityLimits::default());
+        let text = extract_text_from_xhtml_budgeted(&xhtml, &mut budget);
+        assert!(text.contains("lead"), "got: {text}");
+        assert!(text.contains("tail"), "got: {text}");
+    }
+
+    #[test]
+    fn test_deeply_nested_svg_does_not_overflow_the_stack() {
+        let depth = 50_000;
+        let mut xhtml = String::from("<html><body><svg>");
+        for _ in 0..depth {
+            xhtml.push_str("<g>");
+        }
+        xhtml.push_str("<text>deep</text>");
+        for _ in 0..depth {
+            xhtml.push_str("</g>");
+        }
+        xhtml.push_str("</svg><p>tail</p></body></html>");
+
+        let text = extract_text_from_xhtml(&xhtml);
+        assert!(text.contains("tail"), "got: {text}");
     }
 }

--- a/crates/xberg/src/extractors/epub/content.rs
+++ b/crates/xberg/src/extractors/epub/content.rs
@@ -36,9 +36,11 @@ pub(super) struct EpubSpineDocument {
 pub(super) fn read_body_documents(
     archive: &mut ZipArchive<Cursor<Vec<u8>>>,
     package: &EpubPackageDocument,
+    encrypted_members: &std::collections::BTreeSet<String>,
 ) -> crate::Result<(Vec<EpubSpineDocument>, Vec<ProcessingWarning>)> {
     let mut documents = Vec::new();
     let mut warnings = Vec::new();
+    let mut encrypted_count = 0usize;
 
     for spine_item in &package.spine_items {
         let Some(source_item) = package.manifest.get(&spine_item.idref) else {
@@ -95,6 +97,11 @@ pub(super) fn read_body_documents(
                 .as_deref()
                 .is_some_and(|path| package.is_guide_toc_candidate_path(path));
 
+        if encrypted_members.contains(&file_path) {
+            encrypted_count += 1;
+            continue;
+        }
+
         match read_file_from_zip(archive, &file_path) {
             Ok(raw_xhtml) => {
                 let normalized_xhtml = normalize_xhtml(&raw_xhtml);
@@ -135,6 +142,17 @@ pub(super) fn read_body_documents(
                 });
             }
         }
+    }
+
+    if encrypted_count > 0 {
+        warnings.push(ProcessingWarning {
+            source: std::borrow::Cow::Borrowed("epub"),
+            message: std::borrow::Cow::Owned(format!(
+                "The EPUB is encrypted (DRM): {} of {} spine items are listed in META-INF/encryption.xml and were skipped",
+                encrypted_count,
+                package.spine_items.len()
+            )),
+        });
     }
 
     Ok((documents, warnings))

--- a/crates/xberg/src/extractors/epub/content.rs
+++ b/crates/xberg/src/extractors/epub/content.rs
@@ -66,17 +66,19 @@ pub(super) fn read_body_documents(
             }
         };
 
-        let file_path =
-            render_item
-                .resolved_path()
-                .map(str::to_owned)
-                .map_err(|message| crate::XbergError::Parsing {
-                    message: format!(
-                        "Unsafe manifest href for spine item '{}' (href '{}'): {}",
+        let file_path = match render_item.resolved_path() {
+            Ok(path) => path.to_owned(),
+            Err(message) => {
+                warnings.push(ProcessingWarning {
+                    source: std::borrow::Cow::Borrowed("epub"),
+                    message: std::borrow::Cow::Owned(format!(
+                        "Skipping spine item '{}' (href '{}'): unsafe manifest href: {}",
                         spine_item.idref, render_item.raw_href, message
-                    ),
-                    source: None,
-                })?;
+                    )),
+                });
+                continue;
+            }
+        };
         let guide_toc_candidate = source_item
             .path
             .as_deref()

--- a/crates/xberg/src/extractors/epub/content.rs
+++ b/crates/xberg/src/extractors/epub/content.rs
@@ -37,6 +37,7 @@ pub(super) fn read_body_documents(
     archive: &mut ZipArchive<Cursor<Vec<u8>>>,
     package: &EpubPackageDocument,
     encrypted_members: &std::collections::BTreeSet<String>,
+    depth_limit: usize,
 ) -> crate::Result<(Vec<EpubSpineDocument>, Vec<ProcessingWarning>)> {
     let mut documents = Vec::new();
     let mut warnings = Vec::new();
@@ -82,16 +83,15 @@ pub(super) fn read_body_documents(
             }
         };
         // The package names its navigation documents: `properties="nav"` in
-        // EPUB 3, `<guide><reference type="toc">` in EPUB 2. Only a guide target
-        // is checked against the content heuristic, because EPUB 2 guides often
-        // point at a front-matter file that also carries body text.
-        if source_item.is_nav() || render_item.is_nav() {
-            continue;
-        }
-        let guide_toc_candidate = source_item
-            .path
-            .as_deref()
-            .is_some_and(|path| package.is_guide_toc_candidate_path(path))
+        // EPUB 3, `<guide><reference type="toc">` in EPUB 2. Only those items
+        // are checked against the content heuristic, because a navigation
+        // document often also carries body prose that must be kept.
+        let navigation_candidate = source_item.is_nav()
+            || render_item.is_nav()
+            || source_item
+                .path
+                .as_deref()
+                .is_some_and(|path| package.is_guide_toc_candidate_path(path))
             || render_item
                 .path
                 .as_deref()
@@ -105,16 +105,35 @@ pub(super) fn read_body_documents(
         match read_file_from_zip(archive, &file_path) {
             Ok(raw_xhtml) => {
                 let normalized_xhtml = normalize_xhtml(&raw_xhtml);
+                // `roxmltree` parses recursively, so a chapter past the depth
+                // limit keeps only its plain text and no pass parses its markup.
+                if nesting_depth_exceeds(&normalized_xhtml, depth_limit) {
+                    warnings.push(ProcessingWarning {
+                        source: std::borrow::Cow::Borrowed("epub"),
+                        message: std::borrow::Cow::Owned(format!(
+                            "Spine item '{}' is nested deeper than {} elements; only its plain text was kept",
+                            file_path, depth_limit
+                        )),
+                    });
+                    let text = strip_html_tags(&normalized_xhtml);
+                    if !text.is_empty() {
+                        documents.push(EpubSpineDocument {
+                            file_path,
+                            xhtml: format!("<html><body><p>{}</p></body></html>", html_escape::encode_text(&text)),
+                        });
+                    }
+                    continue;
+                }
                 let render_xhtml = strip_embedded_media_elements(&strip_specialized_navigation_sections(
                     &strip_document_head(&normalized_xhtml),
                 ));
 
-                if guide_toc_candidate && looks_like_navigation_document(&render_xhtml) {
+                if navigation_candidate && looks_like_navigation_document(&render_xhtml) {
                     continue;
                 }
 
-                let (text, parse_error) = extract_text_from_xhtml_reporting(&render_xhtml);
-                if let Some(error) = parse_error {
+                let chapter = extract_text_from_xhtml_reporting(&render_xhtml);
+                if let Some(error) = chapter.parse_error {
                     warnings.push(ProcessingWarning {
                         source: std::borrow::Cow::Borrowed("epub"),
                         message: std::borrow::Cow::Owned(format!(
@@ -123,7 +142,7 @@ pub(super) fn read_body_documents(
                         )),
                     });
                 }
-                if text.is_empty() && !has_image_markup(&render_xhtml) {
+                if chapter.text.is_empty() && !has_image_markup(&render_xhtml) {
                     continue;
                 }
 
@@ -179,6 +198,11 @@ fn resolve_renderable_manifest_item<'a>(
         }
 
         let Some(next_id) = item.fallback.as_deref() else {
+            // EPUB 3 allows an SVG content document in the spine. It is rendered
+            // through the SVG text walk when no XHTML fallback exists.
+            if item.is_svg() {
+                return Ok(item);
+            }
             let media_type = item.media_type.as_deref().unwrap_or("unknown");
             return Err(format!(
                 "no renderable XHTML/DTBook fallback found for media type '{}'",
@@ -426,7 +450,7 @@ const BLOCK_ELEMENTS: &[&str] = &[
 /// `math` is handled separately (see `render_math_element`): its subtree is
 /// converted to LaTeX rather than skipped, so it is deliberately absent here.
 ///
-/// `svg` is also handled separately (see `visit_svg_node`): its subtree is walked
+/// `svg` is also handled separately (see `walk_text`): its subtree is walked
 /// selectively rather than skipped outright, so real alt-text (`<title>`/`<desc>`) is
 /// not lost (issue #140). `object`, `embed`, and `iframe` are likewise absent: their
 /// fallback content (`<object><p>fallback</p></object>`) is ordinary child markup, so
@@ -439,76 +463,6 @@ const SKIP_ELEMENTS: &[&str] = &["head", "script", "style", "video", "audio", "s
 /// (`extractors::xml`). Every other SVG element (`path`, `rect`, `circle`, `g`, ...) is
 /// pure drawing geometry with no meaningful text of its own.
 const SVG_TEXT_ELEMENTS: &[&str] = &["title", "desc", "text", "tspan", "textpath"];
-
-/// Element depth at which the recursive text walks stop descending.
-///
-/// `roxmltree` builds its tree without recursion, so a chapter nested tens of
-/// thousands of elements deep parses fine and then overflows the stack in the
-/// walks below. The unbudgeted walk uses this constant; the budgeted walk uses
-/// `SecurityBudget::enter`, whose default limit is the same value.
-const MAX_WALK_DEPTH: usize = 1024;
-
-/// Walk an `<svg>` subtree, extracting text only from [`SVG_TEXT_ELEMENTS`] descendants.
-///
-/// Unlike the generic block-element walk, this never emits text from arbitrary elements —
-/// only once `in_text_context` has been set by entering an allowed tag — so drawing
-/// primitives (`path`, `rect`, ...) can never leak stray text even if a producer ever puts
-/// whitespace or comments between their tags.
-fn visit_svg_node(
-    node: roxmltree::Node<'_, '_>,
-    output: &mut String,
-    in_text_context: bool,
-    budget: Option<&mut SecurityBudget>,
-    depth: usize,
-) {
-    if depth > MAX_WALK_DEPTH {
-        return;
-    }
-    let mut budget = budget;
-    match node.node_type() {
-        roxmltree::NodeType::Text if in_text_context => {
-            let text = node.text().unwrap_or("");
-            if let Some(b) = budget.as_deref_mut()
-                && b.check_entity(text).is_err()
-            {
-                return;
-            }
-            let normalised = normalise_inline_whitespace(text);
-            if normalised.is_empty() {
-                return;
-            }
-            let fragment = if output.is_empty() || output.ends_with('\n') {
-                normalised.trim_start().to_string()
-            } else {
-                normalised
-            };
-            if fragment.is_empty() {
-                return;
-            }
-            if let Some(b) = budget.as_deref_mut()
-                && b.account_text(fragment.len()).is_err()
-            {
-                return;
-            }
-            output.push_str(&fragment);
-        }
-        roxmltree::NodeType::Element => {
-            let tag = node.tag_name().name().to_ascii_lowercase();
-            let entering_text_tag = SVG_TEXT_ELEMENTS.contains(&tag.as_str());
-            let child_in_text_context = in_text_context || entering_text_tag;
-            if entering_text_tag && !output.is_empty() && !output.ends_with('\n') {
-                output.push('\n');
-            }
-            for child in node.children() {
-                visit_svg_node(child, output, child_in_text_context, budget.as_deref_mut(), depth + 1);
-            }
-            if entering_text_tag && !output.is_empty() && !output.ends_with('\n') {
-                output.push('\n');
-            }
-        }
-        _ => {}
-    }
-}
 
 /// Convert a `<math>` element to LaTeX and append it to `output` as its own
 /// `$$...$$` block, isolated by blank lines so it survives the `\n\n` paragraph
@@ -542,42 +496,63 @@ fn render_math_element(node: roxmltree::Node<'_, '_>, output: &mut String, budge
 ///
 /// When `budget` is provided, entity and growth limits are enforced during traversal.
 pub(super) fn extract_text_from_xhtml(xhtml: &str) -> String {
-    extract_text_from_xhtml_with_budget(xhtml, None).0
+    extract_text_from_xhtml_reporting(xhtml).text
 }
 
-/// Like [`extract_text_from_xhtml`], but also returns the XML parse error when
-/// the chapter is not well-formed and the text came from the tag stripper.
-pub(super) fn extract_text_from_xhtml_reporting(xhtml: &str) -> (String, Option<String>) {
-    extract_text_from_xhtml_with_budget(xhtml, None)
+/// Text of a chapter plus what went wrong while reading it.
+pub(super) struct ChapterText {
+    pub(super) text: String,
+    /// The XML parse error when the chapter is not well-formed and the text
+    /// came from the tag stripper.
+    pub(super) parse_error: Option<String>,
+}
+
+/// Like [`extract_text_from_xhtml`], but also reports a parse failure.
+/// Uses the default security limits.
+pub(super) fn extract_text_from_xhtml_reporting(xhtml: &str) -> ChapterText {
+    let mut budget = SecurityBudget::with_defaults();
+    extract_text_from_xhtml_with_budget(xhtml, &mut budget)
 }
 
 pub(super) fn extract_text_from_xhtml_budgeted(xhtml: &str, budget: &mut SecurityBudget) -> String {
-    extract_text_from_xhtml_with_budget(xhtml, Some(budget)).0
+    extract_text_from_xhtml_with_budget(xhtml, budget).text
 }
 
-/// Walk the parsed chapter and collect its text. When `budget` is given, entity
-/// and growth violations stop the walk early and the partial output is kept.
-/// When the chapter is not well-formed XML, or the walk yields no text, the
-/// tag stripper runs instead. The second value is the parse error, if any.
-fn extract_text_from_xhtml_with_budget(xhtml: &str, budget: Option<&mut SecurityBudget>) -> (String, Option<String>) {
+/// Parse the chapter and collect its text under `budget`. When the chapter is
+/// not well-formed XML, or the walk yields no text, the tag stripper runs instead.
+fn extract_text_from_xhtml_with_budget(xhtml: &str, budget: &mut SecurityBudget) -> ChapterText {
     let sanitized = normalize_xhtml(xhtml);
+
+    // `roxmltree` parses recursively, so the depth check runs before it.
+    if nesting_depth_exceeds(&sanitized, budget.depth_limit()) {
+        return ChapterText {
+            text: strip_html_tags(&sanitized),
+            parse_error: None,
+        };
+    }
 
     let parsed = match roxmltree::Document::parse(&sanitized) {
         Ok(doc) => {
             let mut output = String::with_capacity(xhtml.len() / 2);
-            match budget {
-                Some(budget) => visit_node_budgeted(doc.root(), &mut output, budget),
-                None => visit_node_unbounded(doc.root(), &mut output, 0),
-            }
+            walk_text(doc.root(), &mut output, budget);
             Ok(collapse_blank_lines(&output).trim().to_string())
         }
         Err(err) => Err(err.to_string()),
     };
 
     match parsed {
-        Ok(text) if !text.is_empty() => (text, None),
-        Ok(_) => (strip_html_tags(&sanitized), None),
-        Err(err) => (strip_html_tags(&sanitized), Some(err)),
+        Ok(text) if !text.is_empty() => ChapterText {
+            text,
+            parse_error: None,
+        },
+        Ok(_) => ChapterText {
+            text: strip_html_tags(&sanitized),
+            parse_error: None,
+        },
+        Err(err) => ChapterText {
+            text: strip_html_tags(&sanitized),
+            parse_error: Some(err),
+        },
     }
 }
 
@@ -704,144 +679,172 @@ fn find_doctype_end(tail: &str) -> Option<usize> {
     None
 }
 
-/// Recursively visit an XML node and append its text to `output` (no security budget).
-fn visit_node_unbounded(node: roxmltree::Node<'_, '_>, output: &mut String, depth: usize) {
-    if depth > MAX_WALK_DEPTH {
-        return;
-    }
-    match node.node_type() {
-        roxmltree::NodeType::Text => {
-            let text = node.text().unwrap_or("");
-            let normalised = normalise_inline_whitespace(text);
-            if !normalised.is_empty() {
-                let fragment = if output.is_empty() || output.ends_with('\n') {
-                    normalised.trim_start().to_string()
-                } else {
-                    normalised
-                };
-                if !fragment.is_empty() {
-                    output.push_str(&fragment);
+/// True when the element nesting of `xml` goes deeper than `limit`. The scan
+/// is iterative (quick-xml) and stops at the first element past the limit.
+pub(super) fn nesting_depth_exceeds(xml: &str, limit: usize) -> bool {
+    use quick_xml::events::Event;
+
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut depth = 0usize;
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(_)) => {
+                depth += 1;
+                if depth > limit {
+                    return true;
                 }
             }
+            Ok(Event::End(_)) => depth = depth.saturating_sub(1),
+            Ok(Event::Eof) | Err(_) => return false,
+            Ok(_) => {}
         }
-        roxmltree::NodeType::Element => {
-            let tag = node.tag_name().name().to_ascii_lowercase();
-            if tag == "math" {
-                // No budget is threaded through this (unbounded) traversal, so use
-                // a default-limits budget scoped to this one formula's conversion.
-                let mut budget = SecurityBudget::from_limits(&crate::extractors::security::SecurityLimits::default());
-                render_math_element(node, output, &mut budget);
-                return;
-            }
-            // Issue #140: `<svg>` used to be a whole-subtree skip, dropping its real
-            // `<title>`/`<desc>` alt-text along with the (harmless to lose) drawing
-            // geometry. Walk it selectively instead of skipping outright.
-            if tag == "svg" {
-                visit_svg_node(node, output, false, None, depth + 1);
-                return;
-            }
-            if SKIP_ELEMENTS.iter().any(|&s| s == tag) {
-                return;
-            }
-            if tag == "br" {
-                output.push('\n');
-                return;
-            }
-            if tag == "hr" {
-                if !output.is_empty() && !output.ends_with('\n') {
-                    output.push('\n');
-                }
-                return;
-            }
-            let is_block = BLOCK_ELEMENTS.iter().any(|&s| s == tag);
-            if is_block && !output.is_empty() && !output.ends_with('\n') {
-                output.push('\n');
-            }
-            for child in node.children() {
-                visit_node_unbounded(child, output, depth + 1);
-            }
-            if is_block && !output.is_empty() && !output.ends_with('\n') {
-                output.push('\n');
-            }
-        }
-        roxmltree::NodeType::Root => {
-            for child in node.children() {
-                visit_node_unbounded(child, output, depth + 1);
-            }
-        }
-        _ => {}
     }
 }
 
-/// Recursively visit an XML node and append its text to `output`, enforcing `budget`.
+/// Append the text of every node under `root` to `output`.
 ///
-/// Entity expansion and text growth violations stop recursion early; partial output is returned.
-fn visit_node_budgeted(node: roxmltree::Node<'_, '_>, output: &mut String, budget: &mut SecurityBudget) {
-    match node.node_type() {
-        roxmltree::NodeType::Text => {
-            let text = node.text().unwrap_or("");
-            if budget.check_entity(text).is_err() {
-                return;
+/// The walk is iterative, so a chapter nested tens of thousands of elements
+/// deep cannot overflow the stack. `budget` caps element depth, entity length
+/// and output growth; a subtree past the depth limit is skipped. Inside
+/// `<svg>` only [`SVG_TEXT_ELEMENTS`] contribute text.
+fn walk_text(root: roxmltree::Node<'_, '_>, output: &mut String, budget: &mut SecurityBudget) {
+    let mut walk = TextWalk {
+        output,
+        budget,
+        skip_until: None,
+        svg_depth: 0,
+        svg_text_depth: 0,
+    };
+
+    // `descendants` is pre-order and iterative; the stack of open ancestors
+    // turns it into open/close events without recursion.
+    let mut open: Vec<roxmltree::Node<'_, '_>> = Vec::new();
+    for node in root.descendants() {
+        while let Some(top) = open.last().copied() {
+            if node.parent() == Some(top) {
+                break;
             }
-            let normalised = normalise_inline_whitespace(text);
-            if !normalised.is_empty() {
-                let fragment = if output.is_empty() || output.ends_with('\n') {
-                    normalised.trim_start().to_string()
+            open.pop();
+            walk.close(top);
+        }
+        walk.open(node);
+        open.push(node);
+    }
+    while let Some(top) = open.pop() {
+        walk.close(top);
+    }
+}
+
+struct TextWalk<'o, 'b> {
+    output: &'o mut String,
+    budget: &'b mut SecurityBudget,
+    skip_until: Option<roxmltree::NodeId>,
+    svg_depth: usize,
+    svg_text_depth: usize,
+}
+
+impl TextWalk<'_, '_> {
+    fn push_newline(&mut self) {
+        if !self.output.is_empty() && !self.output.ends_with('\n') {
+            self.output.push('\n');
+        }
+    }
+
+    fn open(&mut self, node: roxmltree::Node<'_, '_>) {
+        if self.skip_until.is_some() {
+            return;
+        }
+        match node.node_type() {
+            roxmltree::NodeType::Text => {
+                if self.svg_depth > 0 && self.svg_text_depth == 0 {
+                    return;
+                }
+                let text = node.text().unwrap_or("");
+                if self.budget.check_entity(text).is_err() {
+                    return;
+                }
+                let normalised = normalise_inline_whitespace(text);
+                let fragment = if self.output.is_empty() || self.output.ends_with('\n') {
+                    normalised.trim_start()
                 } else {
-                    normalised
+                    normalised.as_str()
                 };
-                if !fragment.is_empty() {
-                    if budget.account_text(fragment.len()).is_err() {
-                        return;
+                if fragment.is_empty() || self.budget.account_text(fragment.len()).is_err() {
+                    return;
+                }
+                self.output.push_str(fragment);
+            }
+            roxmltree::NodeType::Element => {
+                if self.budget.enter().is_err() {
+                    self.skip_until = Some(node.id());
+                    return;
+                }
+                let tag = node.tag_name().name().to_ascii_lowercase();
+                if tag == "svg" {
+                    self.svg_depth += 1;
+                    return;
+                }
+                if self.svg_depth > 0 {
+                    if SVG_TEXT_ELEMENTS.contains(&tag.as_str()) {
+                        self.push_newline();
+                        self.svg_text_depth += 1;
                     }
-                    output.push_str(&fragment);
+                    return;
+                }
+                if tag == "math" {
+                    render_math_element(node, self.output, self.budget);
+                    self.skip_until = Some(node.id());
+                    return;
+                }
+                if SKIP_ELEMENTS.contains(&tag.as_str()) {
+                    self.skip_until = Some(node.id());
+                    return;
+                }
+                if tag == "br" {
+                    self.output.push('\n');
+                    self.skip_until = Some(node.id());
+                    return;
+                }
+                if tag == "hr" {
+                    self.push_newline();
+                    self.skip_until = Some(node.id());
+                    return;
+                }
+                if BLOCK_ELEMENTS.contains(&tag.as_str()) {
+                    self.push_newline();
                 }
             }
+            _ => {}
         }
-        roxmltree::NodeType::Element => {
-            let tag = node.tag_name().name().to_ascii_lowercase();
-            if tag == "math" {
-                render_math_element(node, output, budget);
-                return;
+    }
+
+    fn close(&mut self, node: roxmltree::Node<'_, '_>) {
+        if let Some(id) = self.skip_until {
+            if node.id() == id {
+                self.skip_until = None;
+                self.budget.leave();
             }
-            if tag == "svg" {
-                visit_svg_node(node, output, false, Some(budget), 0);
-                return;
-            }
-            if SKIP_ELEMENTS.iter().any(|&s| s == tag) {
-                return;
-            }
-            if tag == "br" {
-                output.push('\n');
-                return;
-            }
-            if tag == "hr" {
-                if !output.is_empty() && !output.ends_with('\n') {
-                    output.push('\n');
-                }
-                return;
-            }
-            let is_block = BLOCK_ELEMENTS.iter().any(|&s| s == tag);
-            if is_block && !output.is_empty() && !output.ends_with('\n') {
-                output.push('\n');
-            }
-            if budget.enter().is_err() {
-                return;
-            }
-            for child in node.children() {
-                visit_node_budgeted(child, output, budget);
-            }
-            budget.leave();
-            if is_block && !output.is_empty() && !output.ends_with('\n') {
-                output.push('\n');
-            }
+            return;
         }
-        roxmltree::NodeType::Root => {
-            for child in node.children() {
-                visit_node_budgeted(child, output, budget);
-            }
+        if !node.is_element() {
+            return;
         }
-        _ => {}
+        self.budget.leave();
+        let tag = node.tag_name().name().to_ascii_lowercase();
+        if tag == "svg" {
+            self.svg_depth = self.svg_depth.saturating_sub(1);
+            return;
+        }
+        if self.svg_depth > 0 {
+            if SVG_TEXT_ELEMENTS.contains(&tag.as_str()) {
+                self.push_newline();
+                self.svg_text_depth = self.svg_text_depth.saturating_sub(1);
+            }
+            return;
+        }
+        if BLOCK_ELEMENTS.contains(&tag.as_str()) {
+            self.push_newline();
+        }
     }
 }
 

--- a/crates/xberg/src/extractors/epub/content.rs
+++ b/crates/xberg/src/extractors/epub/content.rs
@@ -79,6 +79,13 @@ pub(super) fn read_body_documents(
                 continue;
             }
         };
+        // The package names its navigation documents: `properties="nav"` in
+        // EPUB 3, `<guide><reference type="toc">` in EPUB 2. Only a guide target
+        // is checked against the content heuristic, because EPUB 2 guides often
+        // point at a front-matter file that also carries body text.
+        if source_item.is_nav() || render_item.is_nav() {
+            continue;
+        }
         let guide_toc_candidate = source_item
             .path
             .as_deref()
@@ -109,7 +116,7 @@ pub(super) fn read_body_documents(
                         )),
                     });
                 }
-                if text.is_empty() {
+                if text.is_empty() && !has_image_markup(&render_xhtml) {
                     continue;
                 }
 
@@ -269,6 +276,24 @@ pub(super) fn resolve_epub_switch_elements(xhtml: &str, supported_namespaces: &[
         resolved.replace_range(range, "");
     }
     resolved
+}
+
+/// True when the document carries an image element. A cover page, a plate, or
+/// a fixed-layout page has no text but still contributes images and alt text.
+pub(super) fn has_image_markup(xhtml: &str) -> bool {
+    match roxmltree::Document::parse(xhtml) {
+        Ok(doc) => doc.descendants().any(|node| {
+            node.is_element()
+                && matches!(
+                    node.tag_name().name().to_ascii_lowercase().as_str(),
+                    "img" | "svg" | "image" | "picture"
+                )
+        }),
+        Err(_) => {
+            let lower = xhtml.to_ascii_lowercase();
+            lower.contains("<img") || lower.contains("<svg") || lower.contains("<image") || lower.contains("<picture")
+        }
+    }
 }
 
 fn is_epub_element(node: roxmltree::Node<'_, '_>, local_name: &str) -> bool {

--- a/crates/xberg/src/extractors/epub/metadata.rs
+++ b/crates/xberg/src/extractors/epub/metadata.rs
@@ -80,6 +80,13 @@ impl ManifestItem {
             .is_some_and(|p| p.split_ascii_whitespace().any(|v| v.eq_ignore_ascii_case("nav")))
     }
 
+    /// True when the item is an SVG content document.
+    pub(super) fn is_svg(&self) -> bool {
+        self.media_type
+            .as_deref()
+            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case("image/svg+xml"))
+    }
+
     pub(super) fn resolved_path(&self) -> std::result::Result<&str, String> {
         self.path.as_deref().ok_or_else(|| {
             self.path_resolution_error

--- a/crates/xberg/src/extractors/epub/metadata.rs
+++ b/crates/xberg/src/extractors/epub/metadata.rs
@@ -14,12 +14,12 @@ use super::parsing::resolve_path;
 #[derive(Debug, Default, Clone)]
 pub(super) struct OepbMetadata {
     pub(super) title: Option<String>,
-    pub(super) creator: Option<String>,
+    pub(super) creators: Vec<String>,
     pub(super) date: Option<String>,
     pub(super) language: Option<String>,
     pub(super) identifier: Option<String>,
     pub(super) publisher: Option<String>,
-    pub(super) subject: Option<String>,
+    pub(super) subjects: Vec<String>,
     pub(super) description: Option<String>,
     pub(super) rights: Option<String>,
     pub(super) coverage: Option<String>,
@@ -75,9 +75,27 @@ impl ManifestItem {
 
     /// Returns true if this manifest item has the EPUB3 `nav` property.
     pub(super) fn is_nav(&self) -> bool {
+        self.has_property("nav")
+    }
+
+    pub(super) fn has_property(&self, property: &str) -> bool {
         self.properties
             .as_deref()
-            .is_some_and(|p| p.split_ascii_whitespace().any(|v| v.eq_ignore_ascii_case("nav")))
+            .is_some_and(|p| p.split_ascii_whitespace().any(|v| v.eq_ignore_ascii_case(property)))
+    }
+
+    /// True when the item is an image by media type, or by extension when the
+    /// media type is missing.
+    pub(super) fn is_image(&self) -> bool {
+        match self.media_type.as_deref() {
+            Some(media_type) => media_type.trim().to_ascii_lowercase().starts_with("image/"),
+            None => self.raw_href.rsplit_once('.').is_some_and(|(_, ext)| {
+                matches!(
+                    ext.to_ascii_lowercase().as_str(),
+                    "jpg" | "jpeg" | "png" | "gif" | "webp" | "svg" | "bmp"
+                )
+            }),
+        }
     }
 
     /// True when the item is an SVG content document.
@@ -94,6 +112,22 @@ impl ManifestItem {
                 .unwrap_or_else(|| format!("unable to resolve manifest href '{}'", self.raw_href))
         })
     }
+}
+
+/// Dublin Core element namespaces. EPUB 2 and 3 use the 1.1 elements
+/// namespace; OEB 1.2 packages used the 1.0 one.
+const DUBLIN_CORE_NAMESPACE_PREFIX: &str = "http://purl.org/dc/elements/";
+
+/// Pick the publication date from every `dc:date`. EPUB 2 qualifies dates
+/// with `opf:event`; a modification date is used only when no other date
+/// exists.
+fn select_publication_date(dates: Vec<(Option<String>, String)>) -> Option<String> {
+    let preferred = dates.iter().find(|(event, _)| {
+        event
+            .as_deref()
+            .is_none_or(|event| matches!(event, "publication" | "creation" | "original-publication"))
+    });
+    preferred.or_else(|| dates.first()).map(|(_, value)| value.clone())
 }
 
 #[allow(dead_code)]
@@ -135,6 +169,13 @@ pub(super) fn parse_opf(
             };
             let mut manifest: BTreeMap<String, ManifestItem> = BTreeMap::new();
             let mut budget_depth = 0;
+            let mut dates: Vec<(Option<String>, String)> = Vec::new();
+            let mut titles: Vec<(Option<String>, String)> = Vec::new();
+            let mut main_title_id: Option<String> = None;
+            let unique_identifier_id = root
+                .descendants()
+                .find(|node| node.tag_name().name() == "package")
+                .and_then(|node| node.attribute("unique-identifier"));
 
             for node in root.descendants() {
                 budget.step()?;
@@ -152,103 +193,72 @@ pub(super) fn parse_opf(
                         budget.check_attr(attr.name(), attr.value())?;
                     }
                 }
-                match node.tag_name().name() {
-                    "title" => {
-                        if let Some(text) = node.text() {
+                let is_dublin_core = node
+                    .tag_name()
+                    .namespace()
+                    .is_some_and(|namespace| namespace.starts_with(DUBLIN_CORE_NAMESPACE_PREFIX));
+                let local_name = node.tag_name().name().to_ascii_lowercase();
+                if is_dublin_core {
+                    let text = match node.text().map(str::trim).filter(|text| !text.is_empty()) {
+                        Some(text) => {
                             budget.check_entity(text)?;
                             budget.account_text(text.len())?;
-                            package.metadata.title = Some(text.trim().to_string());
+                            text.to_string()
                         }
-                    }
-                    "creator" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.creator = Some(text.trim().to_string());
+                        None => continue,
+                    };
+                    let metadata = &mut package.metadata;
+                    match local_name.as_str() {
+                        "title" => {
+                            titles.push((node.attribute("id").map(str::to_string), text));
+                            continue;
                         }
-                    }
-                    "date" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.date = Some(text.trim().to_string());
+                        "creator" => {
+                            metadata.creators.push(text);
+                            continue;
                         }
-                    }
-                    "language" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.language = Some(text.trim().to_string());
+                        "date" => {
+                            let event = node
+                                .attributes()
+                                .find(|attr| attr.name() == "event")
+                                .map(|attr| attr.value());
+                            dates.push((event.map(str::to_ascii_lowercase), text));
+                            continue;
                         }
-                    }
-                    "identifier" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.identifier = Some(text.trim().to_string());
+                        "language" => metadata.language.get_or_insert(text),
+                        "identifier" => {
+                            let is_unique = node.attribute("id").is_some_and(|id| Some(id) == unique_identifier_id);
+                            if is_unique {
+                                metadata.identifier = Some(text);
+                            } else {
+                                metadata.identifier.get_or_insert(text);
+                            }
+                            continue;
                         }
-                    }
-                    "publisher" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.publisher = Some(text.trim().to_string());
+                        "publisher" => metadata.publisher.get_or_insert(text),
+                        "subject" => {
+                            metadata.subjects.push(text);
+                            continue;
                         }
-                    }
-                    "subject" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.subject = Some(text.trim().to_string());
-                        }
-                    }
-                    "description" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.description = Some(text.trim().to_string());
-                        }
-                    }
-                    "rights" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.rights = Some(text.trim().to_string());
-                        }
-                    }
-                    "coverage" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.coverage = Some(text.trim().to_string());
-                        }
-                    }
-                    "format" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.format = Some(text.trim().to_string());
-                        }
-                    }
-                    "relation" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.relation = Some(text.trim().to_string());
-                        }
-                    }
-                    "source" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.source = Some(text.trim().to_string());
-                        }
-                    }
-                    "type" => {
-                        if let Some(text) = node.text() {
-                            budget.check_entity(text)?;
-                            budget.account_text(text.len())?;
-                            package.metadata.dc_type = Some(text.trim().to_string());
+                        "description" => metadata.description.get_or_insert(text),
+                        "rights" => metadata.rights.get_or_insert(text),
+                        "coverage" => metadata.coverage.get_or_insert(text),
+                        "format" => metadata.format.get_or_insert(text),
+                        "relation" => metadata.relation.get_or_insert(text),
+                        "source" => metadata.source.get_or_insert(text),
+                        "type" => metadata.dc_type.get_or_insert(text),
+                        _ => continue,
+                    };
+                    continue;
+                }
+                match local_name.as_str() {
+                    // EPUB 3 marks the main title with a refining meta element.
+                    "meta" => {
+                        if node.attribute("property") == Some("title-type")
+                            && node.text().map(str::trim) == Some("main")
+                            && let Some(refined) = node.attribute("refines").and_then(|id| id.strip_prefix('#'))
+                        {
+                            main_title_id.get_or_insert(refined.to_string());
                         }
                     }
                     "item" => {
@@ -302,20 +312,28 @@ pub(super) fn parse_opf(
                 budget_depth -= 1;
             }
 
-            let mut cover_item_id = None;
-            for node in root.descendants() {
-                if node.tag_name().name() == "meta"
-                    && node.attribute("name") == Some("cover")
-                    && let Some(content) = node.attribute("content")
-                {
-                    cover_item_id = Some(content.to_string());
-                    break;
-                }
-            }
+            package.metadata.date = select_publication_date(dates);
+            package.metadata.title = titles
+                .iter()
+                .find(|(id, _)| id.is_some() && *id == main_title_id)
+                .or_else(|| titles.first())
+                .map(|(_, text)| text.clone());
 
-            if let Some(cover_id) = cover_item_id
-                && let Some(href) = manifest.get(&cover_id)
-                && let Ok(path) = href.resolved_path()
+            // EPUB 3 marks the cover with a manifest property; EPUB 2 points at it
+            // from a meta element. Either way the item has to be an image: some
+            // producers point the meta at the cover XHTML page instead.
+            let cover_from_property = manifest
+                .values()
+                .find(|item| item.has_property("cover-image"))
+                .filter(|item| item.is_image());
+            let cover_from_meta = root
+                .descendants()
+                .find(|node| node.tag_name().name() == "meta" && node.attribute("name") == Some("cover"))
+                .and_then(|node| node.attribute("content"))
+                .and_then(|id| manifest.get(id))
+                .filter(|item| item.is_image());
+            if let Some(item) = cover_from_property.or(cover_from_meta)
+                && let Ok(path) = item.resolved_path()
             {
                 package.metadata.cover_image_href = Some(path.to_string());
             }
@@ -352,7 +370,7 @@ pub(super) fn build_additional_metadata(epub_metadata: &OepbMetadata) -> BTreeMa
         additional_metadata.insert("publisher".to_string(), serde_json::json!(publisher.clone()));
     }
 
-    if let Some(ref subject) = epub_metadata.subject {
+    if let Some(subject) = epub_metadata.subjects.first() {
         additional_metadata.insert("subject".to_string(), serde_json::json!(subject.clone()));
     }
 
@@ -377,8 +395,9 @@ mod tests {
         let siblings = (0..100)
             .map(|index| format!(r#"<item id="item{index}" href="chapter{index}.xhtml"/>"#))
             .collect::<String>();
-        let xml =
-            format!(r#"<package><metadata><title>Book</title></metadata><manifest>{siblings}</manifest></package>"#);
+        let xml = format!(
+            r#"<package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata><dc:title>Book</dc:title></metadata><manifest>{siblings}</manifest></package>"#
+        );
         let limits = SecurityLimits {
             max_nesting_depth: 4,
             max_xml_depth: 4,
@@ -408,5 +427,99 @@ mod tests {
             .expect_err("an OPF deeper than the configured limit should be rejected");
 
         assert!(error.to_string().contains("Nesting too deep"));
+    }
+
+    fn parse(xml: &str) -> EpubPackageDocument {
+        let mut budget = SecurityBudget::with_defaults();
+        parse_opf(xml, "OEBPS", &mut budget).expect("OPF should parse").0
+    }
+
+    #[test]
+    fn should_keep_the_first_title_and_every_creator_and_subject() {
+        let package = parse(
+            r#"<package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" unique-identifier="isbn">
+  <metadata>
+    <dc:title>Main Title</dc:title>
+    <dc:title>Subtitle</dc:title>
+    <dc:creator opf:role="aut">Alice Author</dc:creator>
+    <dc:creator opf:role="ill">Ivan Illustrator</dc:creator>
+    <dc:date opf:event="modification">2020-02-02</dc:date>
+    <dc:date opf:event="publication">1999-01-01</dc:date>
+    <dc:identifier id="uuid">urn:uuid:1</dc:identifier>
+    <dc:identifier id="isbn">9780000000000</dc:identifier>
+    <dc:subject>Fiction</dc:subject>
+    <dc:subject>Adventure</dc:subject>
+  </metadata>
+  <collection role="series"><metadata><title>Series Name</title></metadata></collection>
+</package>"#,
+        );
+        let metadata = package.metadata;
+        assert_eq!(metadata.title.as_deref(), Some("Main Title"));
+        assert_eq!(metadata.creators, vec!["Alice Author", "Ivan Illustrator"]);
+        assert_eq!(metadata.date.as_deref(), Some("1999-01-01"));
+        assert_eq!(metadata.identifier.as_deref(), Some("9780000000000"));
+        assert_eq!(metadata.subjects, vec!["Fiction", "Adventure"]);
+    }
+
+    #[test]
+    fn should_prefer_the_title_refined_as_main() {
+        let package = parse(
+            r##"<package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" version="3.0">
+  <metadata>
+    <dc:title id="sub">A Subtitle</dc:title>
+    <dc:title id="main">The Main Title</dc:title>
+    <meta refines="#main" property="title-type">main</meta>
+    <meta refines="#sub" property="title-type">subtitle</meta>
+  </metadata>
+</package>"##,
+        );
+        assert_eq!(package.metadata.title.as_deref(), Some("The Main Title"));
+    }
+
+    #[test]
+    fn should_use_the_modification_date_only_when_no_other_date_exists() {
+        let package = parse(
+            r#"<package xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf"><metadata>
+    <dc:date opf:event="modification">2020-02-02</dc:date>
+</metadata></package>"#,
+        );
+        assert_eq!(package.metadata.date.as_deref(), Some("2020-02-02"));
+    }
+
+    #[test]
+    fn should_read_oeb12_capitalised_dublin_core_elements() {
+        let package = parse(
+            r#"<package xmlns:dc="http://purl.org/dc/elements/1.0/"><metadata><dc-metadata>
+    <dc:Title>Old Book</dc:Title><dc:Creator>Old Author</dc:Creator>
+</dc-metadata></metadata></package>"#,
+        );
+        assert_eq!(package.metadata.title.as_deref(), Some("Old Book"));
+        assert_eq!(package.metadata.creators, vec!["Old Author"]);
+    }
+
+    #[test]
+    fn should_find_an_epub3_cover_image_property() {
+        let package = parse(
+            r#"<package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata><dc:title>T</dc:title></metadata>
+<manifest>
+  <item id="cover" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image"/>
+  <item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>
+</manifest></package>"#,
+        );
+        assert_eq!(
+            package.metadata.cover_image_href.as_deref(),
+            Some("OEBPS/images/cover.jpg")
+        );
+    }
+
+    #[test]
+    fn should_ignore_a_cover_meta_that_points_at_an_xhtml_page() {
+        let package = parse(
+            r#"<package xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata><dc:title>T</dc:title><meta name="cover" content="coverpage"/></metadata>
+<manifest>
+  <item id="coverpage" href="cover.xhtml" media-type="application/xhtml+xml"/>
+</manifest></package>"#,
+        );
+        assert_eq!(package.metadata.cover_image_href, None);
     }
 }

--- a/crates/xberg/src/extractors/epub/mod.rs
+++ b/crates/xberg/src/extractors/epub/mod.rs
@@ -766,9 +766,12 @@ impl InternalDocumentExtractor for EpubExtractor {
         doc.processing_warnings.extend(processing_warnings);
 
         let output_format = doc.metadata.output_format.take();
+        let creators = package.metadata.creators;
+        let subjects = package.metadata.subjects;
         doc.metadata = Metadata {
             title: package.metadata.title,
-            authors: package.metadata.creator.map(|c| vec![c]),
+            authors: (!creators.is_empty()).then_some(creators),
+            keywords: (!subjects.is_empty()).then_some(subjects),
             language: package.metadata.language,
             created_at: package.metadata.date,
             format: Some(epub_format_metadata),

--- a/crates/xberg/src/extractors/epub/mod.rs
+++ b/crates/xberg/src/extractors/epub/mod.rs
@@ -762,7 +762,7 @@ impl InternalDocumentExtractor for EpubExtractor {
             Default::default()
         };
         let (spine_documents, mut body_warnings) =
-            content::read_body_documents(&mut archive, &package, &encrypted_members)?;
+            content::read_body_documents(&mut archive, &package, &encrypted_members, budget.depth_limit())?;
         processing_warnings.append(&mut body_warnings);
 
         let metadata_map: AHashMap<Cow<'static, str>, serde_json::Value> = additional_metadata

--- a/crates/xberg/src/extractors/epub/mod.rs
+++ b/crates/xberg/src/extractors/epub/mod.rs
@@ -31,7 +31,7 @@ use std::io::{Cursor, Read};
 use zip::ZipArchive;
 
 use crate::extractors::security::{SecurityBudget, ZipBombValidator};
-use content::{extract_text_from_xhtml, extract_text_from_xhtml_budgeted, looks_like_navigation_document};
+use content::{extract_text_from_xhtml, extract_text_from_xhtml_budgeted};
 use metadata::{build_additional_metadata, parse_opf};
 use parsing::{MAX_EPUB_MEMBER_SIZE, parse_container_xml, read_file_from_zip, resolve_path};
 
@@ -320,13 +320,9 @@ impl EpubExtractor {
                 }
             }
 
-            if looks_like_navigation_document(sanitized) {
-                continue;
-            }
-
             let _ = budget.account_text(sanitized.len());
 
-            if extract_text_from_xhtml_budgeted(sanitized, budget).is_empty() {
+            if extract_text_from_xhtml_budgeted(sanitized, budget).is_empty() && !content::has_image_markup(sanitized) {
                 continue;
             }
 

--- a/crates/xberg/src/extractors/epub/mod.rs
+++ b/crates/xberg/src/extractors/epub/mod.rs
@@ -33,7 +33,7 @@ use zip::ZipArchive;
 use crate::extractors::security::{SecurityBudget, ZipBombValidator};
 use content::{extract_text_from_xhtml, extract_text_from_xhtml_budgeted};
 use metadata::{build_additional_metadata, parse_opf};
-use parsing::{MAX_EPUB_MEMBER_SIZE, parse_container_xml, read_file_from_zip, resolve_path};
+use parsing::{MAX_EPUB_MEMBER_SIZE, parse_container_xml, parse_encrypted_members, read_file_from_zip, resolve_path};
 
 const MARKUP_SWITCH_NAMESPACES: &[&str] = &[content::XHTML_NAMESPACE, content::MATHML_NAMESPACE];
 const PLAIN_SWITCH_NAMESPACES: &[&str] = &[content::XHTML_NAMESPACE];
@@ -754,7 +754,15 @@ impl InternalDocumentExtractor for EpubExtractor {
             cover_image: package.metadata.cover_image_href.clone(),
         });
 
-        let (spine_documents, mut body_warnings) = content::read_body_documents(&mut archive, &package)?;
+        let encrypted_members = if archive.index_for_name("META-INF/encryption.xml").is_some() {
+            read_file_from_zip(&mut archive, "META-INF/encryption.xml")
+                .map(|xml| parse_encrypted_members(&xml))
+                .unwrap_or_default()
+        } else {
+            Default::default()
+        };
+        let (spine_documents, mut body_warnings) =
+            content::read_body_documents(&mut archive, &package, &encrypted_members)?;
         processing_warnings.append(&mut body_warnings);
 
         let metadata_map: AHashMap<Cow<'static, str>, serde_json::Value> = additional_metadata

--- a/crates/xberg/src/extractors/epub/mod.rs
+++ b/crates/xberg/src/extractors/epub/mod.rs
@@ -548,6 +548,10 @@ impl EpubExtractor {
 
         if all_converted_successfully && !pre_rendered_fragments.is_empty() {
             let mut combined = pre_rendered_fragments.join("\n\n");
+            // html-to-markdown-rs serialises each <math> element into a comment
+            // next to its rendered text; the HTML extractor strips the same
+            // comment once the equation is recovered as LaTeX.
+            combined = super::html::MATHML_COMMENT_RE.replace_all(&combined, "").into_owned();
 
             combined = combined
                 .lines()

--- a/crates/xberg/src/extractors/epub/mod.rs
+++ b/crates/xberg/src/extractors/epub/mod.rs
@@ -235,6 +235,7 @@ impl EpubExtractor {
         );
         let mut pre_rendered_fragments = Vec::new();
         let mut all_converted_successfully = wants_markup;
+        let mut warnings: Vec<ProcessingWarning> = Vec::new();
 
         if let Some(cover_path) = cover_image_path
             && !Self::spine_references_asset(spine_documents, cover_path)
@@ -288,6 +289,15 @@ impl EpubExtractor {
 
         for (index, spine_doc) in spine_documents.iter().enumerate() {
             if budget.step().is_err() {
+                warnings.push(ProcessingWarning {
+                    source: Cow::Borrowed(EPUB_WARNING_SOURCE),
+                    message: Cow::Owned(format!(
+                        "Iteration limit reached; {} of {} spine items were not extracted (first skipped: '{}')",
+                        spine_documents.len() - index,
+                        spine_documents.len(),
+                        spine_doc.file_path
+                    )),
+                });
                 break;
             }
 
@@ -302,6 +312,7 @@ impl EpubExtractor {
 
             if wants_markup {
                 let rendered = Self::render_spine_document(spine_doc, sanitized, index, config);
+                warnings.extend(rendered.warnings);
                 if rendered.content_fully_converted {
                     pre_rendered_fragments.push(rendered.content_fragment);
                 } else {
@@ -537,6 +548,7 @@ impl EpubExtractor {
         }
 
         let mut doc = builder.build();
+        doc.processing_warnings.extend(warnings);
 
         if all_converted_successfully && !pre_rendered_fragments.is_empty() {
             let mut combined = pre_rendered_fragments.join("\n\n");

--- a/crates/xberg/src/extractors/epub/parsing.rs
+++ b/crates/xberg/src/extractors/epub/parsing.rs
@@ -86,10 +86,10 @@ pub(super) fn read_file_from_zip(archive: &mut ZipArchive<Cursor<Vec<u8>>>, path
     let path: &str = &path;
     match archive.by_name(path) {
         Ok(file) => {
-            let mut content = String::new();
+            let mut bytes = Vec::new();
             let mut bounded = std::io::Read::take(file, MAX_EPUB_MEMBER_SIZE);
-            match std::io::Read::read_to_string(&mut bounded, &mut content) {
-                Ok(_) => Ok(content),
+            match std::io::Read::read_to_end(&mut bounded, &mut bytes) {
+                Ok(_) => decode_member_text(&bytes),
                 Err(e) => Err(crate::XbergError::Parsing {
                     message: format!("Failed to read file from EPUB: {}", e),
                     source: None,
@@ -101,6 +101,76 @@ pub(super) fn read_file_from_zip(archive: &mut ZipArchive<Cursor<Vec<u8>>>, path
             source: None,
         }),
     }
+}
+
+/// Decode an XML member to text. A byte order mark selects UTF-16 or UTF-8.
+/// Valid UTF-8 is taken as is. Anything else goes through the
+/// `<?xml encoding="..."?>` declaration, or charset detection when the
+/// declaration is missing. Bytes that do not decode in the selected encoding
+/// are an error, not replacement characters: an encrypted or binary member
+/// must not surface as text.
+pub(super) fn decode_member_text(bytes: &[u8]) -> Result<String> {
+    if let Some((encoding, bom_len)) = encoding_rs::Encoding::for_bom(bytes) {
+        let (decoded, had_errors) = encoding.decode_without_bom_handling(&bytes[bom_len..]);
+        if had_errors {
+            return Err(crate::XbergError::Parsing {
+                message: format!("Failed to decode file from EPUB as {}", encoding.name()),
+                source: None,
+            });
+        }
+        return Ok(decoded.into_owned());
+    }
+
+    if let Ok(text) = std::str::from_utf8(bytes) {
+        return Ok(text.to_string());
+    }
+
+    let (text, replaced_characters) = crate::utils::xml_utils::decode_xml_to_utf8(bytes);
+    if replaced_characters {
+        return Err(crate::XbergError::Parsing {
+            message: "Failed to decode file from EPUB: the bytes are not valid text in the declared encoding"
+                .to_string(),
+            source: None,
+        });
+    }
+    Ok(text)
+}
+
+/// Font obfuscation algorithms. A package that lists only these in
+/// `META-INF/encryption.xml` is not DRM-protected.
+const FONT_OBFUSCATION_ALGORITHMS: &[&str] = &["http://www.idpf.org/2008/embedding", "http://ns.adobe.com/pdf/enc#RC"];
+
+/// Return the package-relative paths of the members that
+/// `META-INF/encryption.xml` encrypts with an algorithm other than font
+/// obfuscation.
+pub(super) fn parse_encrypted_members(xml: &str) -> std::collections::BTreeSet<String> {
+    let mut encrypted = std::collections::BTreeSet::new();
+    let Ok(doc) = parse_packaging_xml(xml) else {
+        return encrypted;
+    };
+    for data in doc
+        .descendants()
+        .filter(|node| node.is_element() && node.tag_name().name() == "EncryptedData")
+    {
+        let algorithm = data
+            .descendants()
+            .find(|node| node.tag_name().name() == "EncryptionMethod")
+            .and_then(|node| node.attribute("Algorithm"))
+            .unwrap_or("");
+        if FONT_OBFUSCATION_ALGORITHMS.contains(&algorithm) {
+            continue;
+        }
+        for uri in data
+            .descendants()
+            .filter(|node| node.tag_name().name() == "CipherReference")
+            .filter_map(|node| node.attribute("URI"))
+        {
+            if let Ok(resolved) = resolve_path("", uri) {
+                encrypted.insert(resolved.path);
+            }
+        }
+    }
+    encrypted
 }
 
 fn split_href(href: &str) -> (&str, Option<&str>) {
@@ -230,6 +300,47 @@ mod tests {
     fn test_resolve_path_decodes_a_percent_encoded_href() {
         let resolved = resolve_path("contents", "a7b196ae@d22925c%3Ab4e683fb.xhtml").expect("resolves");
         assert_eq!(resolved.path, "contents/a7b196ae@d22925c:b4e683fb.xhtml");
+    }
+
+    #[test]
+    fn should_decode_latin1_and_utf16_members() {
+        let latin1 = b"<?xml version=\"1.0\" encoding=\"iso-8859-1\"?><p>caf\xe9</p>";
+        assert_eq!(
+            decode_member_text(latin1).expect("latin-1 decodes"),
+            "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?><p>caf\u{e9}</p>"
+        );
+
+        let mut utf16 = vec![0xFF, 0xFE];
+        for unit in "<p>caf\u{e9}</p>".encode_utf16() {
+            utf16.extend_from_slice(&unit.to_le_bytes());
+        }
+        assert_eq!(decode_member_text(&utf16).expect("utf-16 decodes"), "<p>caf\u{e9}</p>");
+
+        let utf8_bom = b"\xEF\xBB\xBF<p>x</p>";
+        assert_eq!(decode_member_text(utf8_bom).expect("utf-8 decodes"), "<p>x</p>");
+    }
+
+    #[test]
+    fn should_reject_bytes_that_are_not_text() {
+        let declared_utf8 = b"<?xml version=\"1.0\" encoding=\"utf-8\"?><p>\x80\xFF\x00\xC3</p>";
+        let error = decode_member_text(declared_utf8).expect_err("invalid UTF-8 under a UTF-8 declaration is not text");
+        assert!(error.to_string().contains("Failed to decode"));
+    }
+
+    #[test]
+    fn should_list_encrypted_members_but_not_obfuscated_fonts() {
+        let xml = r#"<encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+  <enc:EncryptedData>
+    <enc:EncryptionMethod Algorithm="http://www.idpf.org/2008/embedding"/>
+    <enc:CipherData><enc:CipherReference URI="OEBPS/fonts/a.otf"/></enc:CipherData>
+  </enc:EncryptedData>
+  <enc:EncryptedData>
+    <enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+    <enc:CipherData><enc:CipherReference URI="OEBPS/c1.xhtml"/></enc:CipherData>
+  </enc:EncryptedData>
+</encryption>"#;
+        let encrypted = parse_encrypted_members(xml);
+        assert_eq!(encrypted.into_iter().collect::<Vec<_>>(), vec!["OEBPS/c1.xhtml"]);
     }
 
     /// A space is written `%20`, which must not stay literal either.

--- a/crates/xberg/src/extractors/html.rs
+++ b/crates/xberg/src/extractors/html.rs
@@ -317,7 +317,7 @@ static ALT_ATTR_RE: std::sync::LazyLock<regex::Regex> =
 /// serializes the raw MathML XML and leaks straight into `pre_rendered_content`/plain text
 /// output; it carries no value once the equation has been recovered as LaTeX below, so it
 /// is stripped.
-static MATHML_COMMENT_RE: std::sync::LazyLock<regex::Regex> =
+pub(crate) static MATHML_COMMENT_RE: std::sync::LazyLock<regex::Regex> =
     std::sync::LazyLock::new(|| regex::Regex::new(r"(?is)<!--\s*MathML:.*?-->\s*").unwrap());
 
 /// Recover MathML equations as LaTeX `Formula` elements (issue #129).

--- a/crates/xberg/src/extractors/security.rs
+++ b/crates/xberg/src/extractors/security.rs
@@ -686,6 +686,11 @@ impl SecurityBudget {
         self.depth.pop();
     }
 
+    /// The element depth at which [`SecurityBudget::enter`] starts to fail.
+    pub(crate) fn depth_limit(&self) -> usize {
+        self.depth.max_depth
+    }
+
     /// Account for `len` bytes of emitted text. Returns `Err(ContentTooLarge)`
     /// once total output exceeds `max_content_size`.
     pub(crate) fn account_text(&mut self, len: usize) -> Result<(), SecurityError> {

--- a/crates/xberg/src/rendering/plain.rs
+++ b/crates/xberg/src/rendering/plain.rs
@@ -131,6 +131,12 @@ pub(crate) fn render_plain(doc: &InternalDocument) -> String {
                         out.push_str(&ocr_result.content);
                         out.push_str("\n\n");
                     }
+                } else if !elem.text.trim().is_empty() {
+                    // An image the extractor could not resolve (a missing archive
+                    // member) still carries its alt text or caption.
+                    out.push_str("[Image: ");
+                    out.push_str(elem.text.trim());
+                    out.push_str("]\n\n");
                 }
             }
             ElementKind::FootnoteRef => {}

--- a/crates/xberg/tests/epub_hardening_tests.rs
+++ b/crates/xberg/tests/epub_hardening_tests.rs
@@ -371,3 +371,69 @@ fn build_epub_with_cover_item(metadata: &str, chapter_bytes: &[u8], png: &[u8]) 
     }
     cursor.into_inner()
 }
+
+// ---- #1493: rendering ------------------------------------------------------
+
+fn rendered_content(document: InternalDocument, output_format: OutputFormat) -> String {
+    xberg::extraction::derive::derive_extraction_result(document, false, output_format).content
+}
+
+#[tokio::test]
+async fn test_markdown_output_has_no_mathml_comment() {
+    let body = chapter(
+        r#"<p>Inline <math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></math> here</p>"#,
+    );
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+    let document = extract(&bytes, &markdown_config()).await;
+    let text = plain_text(&document);
+    assert!(!text.contains("<!--"), "MathML comment leaked: {text}");
+    assert!(text.contains("Inline"), "got: {text}");
+}
+
+#[tokio::test]
+async fn test_heading_line_breaks_do_not_leak_control_characters() {
+    let body = chapter("<h2><br/><br/>CHAPTER I.</h2><p>Body text.</p>");
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = rendered_content(document, OutputFormat::Plain);
+    assert!(!text.contains('\x01'), "got: {text:?}");
+    assert!(text.contains("CHAPTER I."), "got: {text}");
+}
+
+#[tokio::test]
+async fn test_nested_table_keeps_the_enclosing_table_rows() {
+    let body = chapter(
+        "<table><tr><td>A1</td><td>A2</td></tr><tr><td><table><tr><td>N1</td></tr></table></td><td>B2</td></tr><tr><td>C1</td><td>C2</td></tr></table>",
+    );
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = rendered_content(document, OutputFormat::Plain);
+    for cell in ["A1", "A2", "N1", "B2", "C1", "C2"] {
+        assert!(text.contains(cell), "cell {cell} missing from: {text}");
+    }
+}
+
+#[tokio::test]
+async fn test_unresolved_image_keeps_its_alt_text_in_plain_output() {
+    let body = chapter(r#"<p>Before.</p><img src="missing.png" alt="A lost plate"/><p>After.</p>"#);
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = rendered_content(document, OutputFormat::Plain);
+    assert!(text.contains("A lost plate"), "got: {text}");
+}

--- a/crates/xberg/tests/epub_hardening_tests.rs
+++ b/crates/xberg/tests/epub_hardening_tests.rs
@@ -1,0 +1,309 @@
+//! EPUB extraction hardening tests.
+//!
+//! Each test builds a minimal EPUB in memory and checks one behaviour that
+//! earlier releases got wrong: dropped chapters, silent failures, and lost
+//! metadata.
+
+#![cfg(feature = "office")]
+
+use std::io::{Cursor, Write};
+use xberg::core::config::{ExtractionConfig, OutputFormat};
+use xberg::extractors::EpubExtractor;
+use xberg::plugins::InternalDocumentExtractor;
+use xberg::types::internal::{ElementKind, InternalDocument};
+use zip::write::FileOptions;
+
+const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+fn chapter(body: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Chapter</title></head><body>{body}</body></html>"#
+    )
+}
+
+/// Build an EPUB with the given manifest items (`(id, href, media-type, extra attrs)`)
+/// placed in the spine in order, plus arbitrary members.
+fn build_epub(metadata: &str, items: &[(&str, &str, &str, &str)], members: &[(&str, &[u8])]) -> Vec<u8> {
+    let manifest = items
+        .iter()
+        .map(|(id, href, media_type, extra)| {
+            format!(r#"<item id="{id}" href="{href}" media-type="{media_type}" {extra}/>"#)
+        })
+        .collect::<String>();
+    let spine = items
+        .iter()
+        .map(|(id, _, _, _)| format!(r#"<itemref idref="{id}"/>"#))
+        .collect::<String>();
+    let opf = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">{metadata}</metadata>
+  <manifest>{manifest}</manifest>
+  <spine>{spine}</spine>
+</package>"#
+    );
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut cursor);
+        let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+        writer.start_file("mimetype", options).expect("zip start_file failed");
+        writer.write_all(b"application/epub+zip").expect("zip write failed");
+        writer.start_file("META-INF/container.xml", options).expect("zip start_file failed");
+        writer.write_all(CONTAINER_XML.as_bytes()).expect("zip write failed");
+        writer.start_file("OEBPS/content.opf", options).expect("zip start_file failed");
+        writer.write_all(opf.as_bytes()).expect("zip write failed");
+        for (path, bytes) in members {
+            writer.start_file(*path, options).expect("zip start_file failed");
+            writer.write_all(bytes).expect("zip write failed");
+        }
+        writer.finish().expect("zip finish failed");
+    }
+    cursor.into_inner()
+}
+
+const BASIC_METADATA: &str = r#"<dc:title>Hardening Test</dc:title><dc:language>en</dc:language>"#;
+
+async fn extract(bytes: &[u8], config: &ExtractionConfig) -> InternalDocument {
+    EpubExtractor
+        .extract_content(bytes, "application/epub+zip", config)
+        .await
+        .expect("extraction failed")
+}
+
+fn plain_text(document: &InternalDocument) -> String {
+    if let Some(content) = &document.pre_rendered_content {
+        return content.clone();
+    }
+    document
+        .elements
+        .iter()
+        .filter(|element| {
+            !matches!(
+                element.kind,
+                ElementKind::ListStart { .. }
+                    | ElementKind::ListEnd
+                    | ElementKind::QuoteStart
+                    | ElementKind::QuoteEnd
+                    | ElementKind::GroupStart
+                    | ElementKind::GroupEnd
+                    | ElementKind::PageBreak
+                    | ElementKind::Image { .. }
+                    | ElementKind::Table { .. }
+            )
+        })
+        .map(|element| element.text.as_str())
+        .filter(|text| !text.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn markdown_config() -> ExtractionConfig {
+    ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        ..ExtractionConfig::default()
+    }
+}
+
+// ---- #1489: spine gating -------------------------------------------------
+
+#[tokio::test]
+async fn test_link_list_chapters_are_kept_in_plain_and_markdown_output() {
+    let further_reading = chapter(
+        r#"<h1>Further Reading</h1><ul><li><a href="http://a">Smith, Alpha</a></li><li><a href="http://b">Doe, Beta</a></li></ul>"#,
+    );
+    let body = chapter("<p>Real chapter one text.</p>");
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[
+            ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+            ("bib", "bib.xhtml", "application/xhtml+xml", ""),
+        ],
+        &[("OEBPS/c1.xhtml", body.as_bytes()), ("OEBPS/bib.xhtml", further_reading.as_bytes())],
+    );
+
+    let plain = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = plain_text(&plain);
+    assert!(text.contains("Real chapter one text."), "got: {text}");
+    assert!(text.contains("Smith, Alpha"), "link-list chapter dropped from plain output: {text}");
+
+    let markdown = extract(&bytes, &markdown_config()).await;
+    let text = plain_text(&markdown);
+    assert!(text.contains("Smith, Alpha"), "link-list chapter dropped from markdown output: {text}");
+}
+
+#[tokio::test]
+async fn test_nav_property_excludes_the_navigation_document_without_a_heuristic() {
+    let nav = chapter(
+        r#"<h1>Contents</h1><p>Intro paragraph.</p><p>Another.</p><p>Third.</p><ol><li><a href="c1.xhtml">One</a></li><li><a href="c2.xhtml">Two</a></li></ol>"#,
+    );
+    let body = chapter("<p>Body text.</p>");
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[
+            ("nav", "nav.xhtml", "application/xhtml+xml", r#"properties="nav""#),
+            ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+        ],
+        &[("OEBPS/nav.xhtml", nav.as_bytes()), ("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = plain_text(&document);
+    assert!(text.contains("Body text."), "got: {text}");
+    assert!(!text.contains("Intro paragraph."), "nav document leaked into content: {text}");
+}
+
+#[tokio::test]
+async fn test_image_only_spine_page_emits_its_image() {
+    let cover_page = chapter(r#"<div><img src="cover.png" alt="Front cover"/></div>"#);
+    let body = chapter("<p>Body text.</p>");
+    let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[
+            ("cover", "cover.xhtml", "application/xhtml+xml", ""),
+            ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+        ],
+        &[
+            ("OEBPS/cover.xhtml", cover_page.as_bytes()),
+            ("OEBPS/cover.png", &png),
+            ("OEBPS/c1.xhtml", body.as_bytes()),
+        ],
+    );
+
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    assert_eq!(document.images.len(), 1, "cover page image was not extracted");
+    assert_eq!(document.images[0].description.as_deref(), Some("Front cover"));
+    assert!(plain_text(&document).contains("Body text."));
+}
+
+#[tokio::test]
+async fn test_svg_spine_document_text_is_extracted() {
+    let svg = r#"<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><title>Plate one</title><text x="1" y="1">SVG spine text</text></svg>"#;
+    let body = chapter("<p>Body text.</p>");
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[
+            ("plate", "plate.svg", "image/svg+xml", ""),
+            ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+        ],
+        &[("OEBPS/plate.svg", svg.as_bytes()), ("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = plain_text(&document);
+    assert!(text.contains("SVG spine text"), "got: {text}");
+    assert!(document.processing_warnings.is_empty(), "got: {:?}", document.processing_warnings);
+}
+
+// ---- #1488: entities and byte order marks --------------------------------
+
+#[tokio::test]
+async fn test_chapter_with_html_entity_and_style_attribute_is_extracted() {
+    let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><link rel="stylesheet" href="s.css"/><title>HEADTITLE</title></head>
+<body style="margin:0"><p style="text-indent:0">First&nbsp;para &mdash; dash</p><p>Second para</p></body></html>"#;
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+
+    for config in [ExtractionConfig::default(), markdown_config()] {
+        let document = extract(&bytes, &config).await;
+        let text = plain_text(&document);
+        assert!(text.contains("First\u{a0}para \u{2014} dash"), "got: {text}");
+        assert!(text.contains("Second para"), "got: {text}");
+        assert!(!text.contains("HEADTITLE"), "head title leaked: {text}");
+        assert!(document.processing_warnings.is_empty(), "got: {:?}", document.processing_warnings);
+    }
+}
+
+#[tokio::test]
+async fn test_chapter_with_byte_order_mark_is_extracted_without_the_prelude() {
+    let mut body = b"\xEF\xBB\xBF".to_vec();
+    body.extend_from_slice(chapter("<p>Bom body</p>").as_bytes());
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", &body)],
+    );
+
+    for config in [ExtractionConfig::default(), markdown_config()] {
+        let document = extract(&bytes, &config).await;
+        let text = plain_text(&document);
+        assert!(text.contains("Bom body"), "got: {text}");
+        assert!(!text.contains("xml version"), "prelude leaked: {text}");
+        assert!(!text.contains('\u{FEFF}'), "BOM leaked: {text:?}");
+    }
+}
+
+// ---- #1490: depth ----------------------------------------------------------
+
+#[tokio::test]
+async fn test_deeply_nested_chapter_does_not_end_the_process() {
+    let depth = 60_000;
+    let mut inner = String::new();
+    for _ in 0..depth {
+        inner.push_str("<span>");
+    }
+    inner.push_str("deep");
+    for _ in 0..depth {
+        inner.push_str("</span>");
+    }
+    let body = chapter(&format!("<p>lead</p><p>{inner}</p><p>tail</p>"));
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[("OEBPS/c1.xhtml", body.as_bytes())],
+    );
+
+    for config in [ExtractionConfig::default(), markdown_config()] {
+        let document = extract(&bytes, &config).await;
+        assert!(plain_text(&document).contains("lead"));
+    }
+}
+
+// ---- #1491: per-item failures ---------------------------------------------
+
+#[tokio::test]
+async fn test_iteration_limit_reports_skipped_spine_items() {
+    let body = chapter("<p>Body text.</p>");
+    let items: Vec<(String, String)> = (0..20).map(|i| (format!("c{i}"), format!("c{i}.xhtml"))).collect();
+    let item_refs: Vec<(&str, &str, &str, &str)> = items
+        .iter()
+        .map(|(id, href)| (id.as_str(), href.as_str(), "application/xhtml+xml", ""))
+        .collect();
+    let members: Vec<(String, &[u8])> = items
+        .iter()
+        .map(|(_, href)| (format!("OEBPS/{href}"), body.as_bytes()))
+        .collect();
+    let member_refs: Vec<(&str, &[u8])> = members.iter().map(|(p, b)| (p.as_str(), *b)).collect();
+    let bytes = build_epub(BASIC_METADATA, &item_refs, &member_refs);
+
+    let config = ExtractionConfig {
+        security_limits: Some(xberg::extractors::security::SecurityLimits {
+            max_iterations: 60,
+            ..Default::default()
+        }),
+        ..ExtractionConfig::default()
+    };
+    let document = extract(&bytes, &config).await;
+    assert!(
+        document
+            .processing_warnings
+            .iter()
+            .any(|warning| warning.message.contains("Iteration limit reached")),
+        "got: {:?}",
+        document.processing_warnings
+    );
+}

--- a/crates/xberg/tests/epub_hardening_tests.rs
+++ b/crates/xberg/tests/epub_hardening_tests.rs
@@ -307,3 +307,67 @@ async fn test_iteration_limit_reports_skipped_spine_items() {
         document.processing_warnings
     );
 }
+
+// ---- #1492: metadata --------------------------------------------------------
+
+#[tokio::test]
+async fn test_metadata_keeps_first_title_all_creators_and_epub3_cover() {
+    let metadata = r#"
+    <dc:title>Main Title</dc:title>
+    <dc:title>Subtitle</dc:title>
+    <dc:creator opf:role="aut">Alice Author</dc:creator>
+    <dc:creator opf:role="ill">Ivan Illustrator</dc:creator>
+    <dc:date opf:event="modification">2020-02-02</dc:date>
+    <dc:date opf:event="publication">1999-01-01</dc:date>
+    <dc:subject>Fiction</dc:subject>
+    <dc:subject>Adventure</dc:subject>
+    <dc:language>en</dc:language>"#;
+    let body = chapter("<p>Body text.</p>");
+    let png = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+    let bytes = build_epub_with_cover_item(metadata, body.as_bytes(), &png);
+
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    assert_eq!(document.metadata.title.as_deref(), Some("Main Title"));
+    assert_eq!(
+        document.metadata.authors.as_deref(),
+        Some(&["Alice Author".to_string(), "Ivan Illustrator".to_string()][..])
+    );
+    assert_eq!(document.metadata.created_at.as_deref(), Some("1999-01-01"));
+    assert_eq!(
+        document.metadata.keywords.as_deref(),
+        Some(&["Fiction".to_string(), "Adventure".to_string()][..])
+    );
+    assert_eq!(document.images.len(), 1, "EPUB 3 cover-image property was ignored");
+    assert_eq!(document.images[0].description.as_deref(), Some("Cover"));
+}
+
+fn build_epub_with_cover_item(metadata: &str, chapter_bytes: &[u8], png: &[u8]) -> Vec<u8> {
+    let opf = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">{metadata}</metadata>
+  <manifest>
+    <item id="cover" href="cover.png" media-type="image/png" properties="cover-image"/>
+    <item id="c1" href="c1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine><itemref idref="c1"/></spine>
+</package>"#
+    );
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut cursor);
+        let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+        for (path, bytes) in [
+            ("mimetype", b"application/epub+zip".as_slice()),
+            ("META-INF/container.xml", CONTAINER_XML.as_bytes()),
+            ("OEBPS/content.opf", opf.as_bytes()),
+            ("OEBPS/c1.xhtml", chapter_bytes),
+            ("OEBPS/cover.png", png),
+        ] {
+            writer.start_file(path, options).expect("zip start_file failed");
+            writer.write_all(bytes).expect("zip write failed");
+        }
+        writer.finish().expect("zip finish failed");
+    }
+    cursor.into_inner()
+}

--- a/crates/xberg/tests/epub_hardening_tests.rs
+++ b/crates/xberg/tests/epub_hardening_tests.rs
@@ -56,9 +56,13 @@ fn build_epub(metadata: &str, items: &[(&str, &str, &str, &str)], members: &[(&s
         let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
         writer.start_file("mimetype", options).expect("zip start_file failed");
         writer.write_all(b"application/epub+zip").expect("zip write failed");
-        writer.start_file("META-INF/container.xml", options).expect("zip start_file failed");
+        writer
+            .start_file("META-INF/container.xml", options)
+            .expect("zip start_file failed");
         writer.write_all(CONTAINER_XML.as_bytes()).expect("zip write failed");
-        writer.start_file("OEBPS/content.opf", options).expect("zip start_file failed");
+        writer
+            .start_file("OEBPS/content.opf", options)
+            .expect("zip start_file failed");
         writer.write_all(opf.as_bytes()).expect("zip write failed");
         for (path, bytes) in members {
             writer.start_file(*path, options).expect("zip start_file failed");
@@ -126,25 +130,61 @@ async fn test_link_list_chapters_are_kept_in_plain_and_markdown_output() {
             ("c1", "c1.xhtml", "application/xhtml+xml", ""),
             ("bib", "bib.xhtml", "application/xhtml+xml", ""),
         ],
-        &[("OEBPS/c1.xhtml", body.as_bytes()), ("OEBPS/bib.xhtml", further_reading.as_bytes())],
+        &[
+            ("OEBPS/c1.xhtml", body.as_bytes()),
+            ("OEBPS/bib.xhtml", further_reading.as_bytes()),
+        ],
     );
 
     let plain = extract(&bytes, &ExtractionConfig::default()).await;
     let text = plain_text(&plain);
     assert!(text.contains("Real chapter one text."), "got: {text}");
-    assert!(text.contains("Smith, Alpha"), "link-list chapter dropped from plain output: {text}");
+    assert!(
+        text.contains("Smith, Alpha"),
+        "link-list chapter dropped from plain output: {text}"
+    );
 
     let markdown = extract(&bytes, &markdown_config()).await;
     let text = plain_text(&markdown);
-    assert!(text.contains("Smith, Alpha"), "link-list chapter dropped from markdown output: {text}");
+    assert!(
+        text.contains("Smith, Alpha"),
+        "link-list chapter dropped from markdown output: {text}"
+    );
 }
 
 #[tokio::test]
-async fn test_nav_property_excludes_the_navigation_document_without_a_heuristic() {
-    let nav = chapter(
-        r#"<h1>Contents</h1><p>Intro paragraph.</p><p>Another.</p><p>Third.</p><ol><li><a href="c1.xhtml">One</a></li><li><a href="c2.xhtml">Two</a></li></ol>"#,
-    );
+async fn test_nav_property_gates_the_navigation_heuristic() {
+    // A pure link list is navigation only when the package says so.
+    let link_list =
+        chapter(r#"<h1>Contents</h1><ol><li><a href="c1.xhtml">One</a></li><li><a href="c2.xhtml">Two</a></li></ol>"#);
     let body = chapter("<p>Body text.</p>");
+    for (properties, expect_present) in [(r#"properties="nav""#, false), ("", true)] {
+        let bytes = build_epub(
+            BASIC_METADATA,
+            &[
+                ("toc", "toc.xhtml", "application/xhtml+xml", properties),
+                ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+            ],
+            &[
+                ("OEBPS/toc.xhtml", link_list.as_bytes()),
+                ("OEBPS/c1.xhtml", body.as_bytes()),
+            ],
+        );
+        let document = extract(&bytes, &ExtractionConfig::default()).await;
+        let text = plain_text(&document);
+        assert!(text.contains("Body text."), "got: {text}");
+        assert_eq!(
+            text.contains("One"),
+            expect_present,
+            "properties={properties:?}: {text}"
+        );
+    }
+
+    // A navigation document keeps the prose it carries next to its <nav>.
+    let nav = chapter(
+        r#"<h1>Front</h1><p>Intro paragraph.</p><nav epub:type="toc"><ol><li><a href="c1.xhtml">One</a></li><li><a href="c2.xhtml">Two</a></li></ol></nav>"#,
+    )
+    .replace("<html xmlns=", r#"<html xmlns:epub="http://www.idpf.org/2007/ops" xmlns="#);
     let bytes = build_epub(
         BASIC_METADATA,
         &[
@@ -153,11 +193,10 @@ async fn test_nav_property_excludes_the_navigation_document_without_a_heuristic(
         ],
         &[("OEBPS/nav.xhtml", nav.as_bytes()), ("OEBPS/c1.xhtml", body.as_bytes())],
     );
-
     let document = extract(&bytes, &ExtractionConfig::default()).await;
     let text = plain_text(&document);
-    assert!(text.contains("Body text."), "got: {text}");
-    assert!(!text.contains("Intro paragraph."), "nav document leaked into content: {text}");
+    assert!(text.contains("Intro paragraph."), "nav prose dropped: {text}");
+    assert!(!text.contains("Two"), "toc entries leaked: {text}");
 }
 
 #[tokio::test]
@@ -201,7 +240,11 @@ async fn test_svg_spine_document_text_is_extracted() {
     let document = extract(&bytes, &ExtractionConfig::default()).await;
     let text = plain_text(&document);
     assert!(text.contains("SVG spine text"), "got: {text}");
-    assert!(document.processing_warnings.is_empty(), "got: {:?}", document.processing_warnings);
+    assert!(
+        document.processing_warnings.is_empty(),
+        "got: {:?}",
+        document.processing_warnings
+    );
 }
 
 // ---- #1488: entities and byte order marks --------------------------------
@@ -221,10 +264,16 @@ async fn test_chapter_with_html_entity_and_style_attribute_is_extracted() {
     for config in [ExtractionConfig::default(), markdown_config()] {
         let document = extract(&bytes, &config).await;
         let text = plain_text(&document);
-        assert!(text.contains("First\u{a0}para \u{2014} dash"), "got: {text}");
+        // Paragraph normalisation may turn the no-break space into a plain space.
+        let text = text.replace('\u{a0}', " ");
+        assert!(text.contains("First para \u{2014} dash"), "got: {text}");
         assert!(text.contains("Second para"), "got: {text}");
         assert!(!text.contains("HEADTITLE"), "head title leaked: {text}");
-        assert!(document.processing_warnings.is_empty(), "got: {:?}", document.processing_warnings);
+        assert!(
+            document.processing_warnings.is_empty(),
+            "got: {:?}",
+            document.processing_warnings
+        );
     }
 }
 
@@ -436,4 +485,106 @@ async fn test_unresolved_image_keeps_its_alt_text_in_plain_output() {
     let document = extract(&bytes, &ExtractionConfig::default()).await;
     let text = rendered_content(document, OutputFormat::Plain);
     assert!(text.contains("A lost plate"), "got: {text}");
+}
+
+// ---- #1494: encoding and DRM ------------------------------------------------
+
+#[tokio::test]
+async fn test_latin1_and_utf16_chapters_are_decoded() {
+    let latin1 = b"<?xml version=\"1.0\" encoding=\"iso-8859-1\"?><html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>caf\xe9 latin</p></body></html>".to_vec();
+    let mut utf16 = vec![0xFF, 0xFE];
+    for unit in "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><p>caf\u{e9} utf16</p></body></html>".encode_utf16()
+    {
+        utf16.extend_from_slice(&unit.to_le_bytes());
+    }
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[
+            ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+            ("c2", "c2.xhtml", "application/xhtml+xml", ""),
+        ],
+        &[("OEBPS/c1.xhtml", &latin1), ("OEBPS/c2.xhtml", &utf16)],
+    );
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = plain_text(&document);
+    assert!(text.contains("caf\u{e9} latin"), "got: {text}");
+    assert!(text.contains("caf\u{e9} utf16"), "got: {text}");
+    assert!(
+        document.processing_warnings.is_empty(),
+        "got: {:?}",
+        document.processing_warnings
+    );
+}
+
+#[tokio::test]
+async fn test_drm_encrypted_spine_items_are_skipped_with_one_warning() {
+    let encryption_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+  <enc:EncryptedData>
+    <enc:EncryptionMethod Algorithm="http://www.idpf.org/2008/embedding"/>
+    <enc:CipherData><enc:CipherReference URI="OEBPS/fonts/a.otf"/></enc:CipherData>
+  </enc:EncryptedData>
+  <enc:EncryptedData>
+    <enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+    <enc:CipherData><enc:CipherReference URI="OEBPS/c1.xhtml"/></enc:CipherData>
+  </enc:EncryptedData>
+</encryption>"#;
+    let ciphertext: Vec<u8> = (0..256u32).map(|i| (i * 73 % 251) as u8).collect();
+    let body = chapter("<p>Clear chapter.</p>");
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[
+            ("c1", "c1.xhtml", "application/xhtml+xml", ""),
+            ("c2", "c2.xhtml", "application/xhtml+xml", ""),
+        ],
+        &[
+            ("META-INF/encryption.xml", encryption_xml.as_bytes()),
+            ("OEBPS/c1.xhtml", &ciphertext),
+            ("OEBPS/c2.xhtml", body.as_bytes()),
+        ],
+    );
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    let text = plain_text(&document);
+    assert!(text.contains("Clear chapter."), "got: {text}");
+    let drm_warnings: Vec<_> = document
+        .processing_warnings
+        .iter()
+        .filter(|warning| warning.message.contains("encrypted (DRM)"))
+        .collect();
+    assert_eq!(drm_warnings.len(), 1, "got: {:?}", document.processing_warnings);
+    assert!(
+        !document
+            .processing_warnings
+            .iter()
+            .any(|w| w.message.contains("valid UTF-8")),
+        "encoding warning blamed DRM bytes: {:?}",
+        document.processing_warnings
+    );
+}
+
+#[tokio::test]
+async fn test_font_obfuscation_only_encryption_is_not_drm() {
+    let encryption_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container" xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+  <enc:EncryptedData>
+    <enc:EncryptionMethod Algorithm="http://www.idpf.org/2008/embedding"/>
+    <enc:CipherData><enc:CipherReference URI="OEBPS/fonts/a.otf"/></enc:CipherData>
+  </enc:EncryptedData>
+</encryption>"#;
+    let body = chapter("<p>Clear chapter.</p>");
+    let bytes = build_epub(
+        BASIC_METADATA,
+        &[("c1", "c1.xhtml", "application/xhtml+xml", "")],
+        &[
+            ("META-INF/encryption.xml", encryption_xml.as_bytes()),
+            ("OEBPS/c1.xhtml", body.as_bytes()),
+        ],
+    );
+    let document = extract(&bytes, &ExtractionConfig::default()).await;
+    assert!(plain_text(&document).contains("Clear chapter."));
+    assert!(
+        document.processing_warnings.is_empty(),
+        "got: {:?}",
+        document.processing_warnings
+    );
 }

--- a/crates/xberg/tests/epub_spine_semantics_tests.rs
+++ b/crates/xberg/tests/epub_spine_semantics_tests.rs
@@ -602,18 +602,23 @@ async fn test_epub_manifest_fallback_resolves_renderable_body_document() {
 }
 
 #[tokio::test]
-async fn test_epub_rejects_manifest_paths_that_escape_package_root() {
+async fn test_epub_skips_manifest_paths_that_escape_package_root_with_a_warning() {
     let bytes = build_epub_with_root_escaping_manifest_href();
     let extractor = EpubExtractor;
 
-    let err = extractor
+    let result = extractor
         .extract_content(&bytes, "application/epub+zip", &ExtractionConfig::default())
         .await
-        .expect_err("EPUB extraction should reject root-escaping manifest paths");
+        .expect("one unsafe spine href must not fail the whole book");
 
+    assert!(content(&result).trim().is_empty(), "the escaping item must not be read");
     assert!(
-        err.to_string().contains("escapes the package root"),
-        "Expected root-escape validation error, got: {err}"
+        result
+            .processing_warnings
+            .iter()
+            .any(|warning| warning.message.contains("escapes the package root")),
+        "Expected a root-escape warning, got: {:?}",
+        result.processing_warnings
     );
 }
 


### PR DESCRIPTION
Draft while verification runs on a pod: gates, a 41-file public corpus regression gate (baseline vs candidate, per spine item), and an independent review of the change set. One commit per issue.

## Chapters that vanished

A chapter with one HTML named entity (`&nbsp;`) and a `style` or `script` substring in any tag extracted as nothing, because the entity broke the XML parse and the tag-stripping fallback swallowed the rest. Entities are expanded before the parse, a byte order mark no longer defeats the prelude stripper, and a chapter that still fails to parse warns instead of vanishing. Fixes #1488.

Bibliographies, endnotes, licence pages and chapter overview pages were dropped by a link-count heuristic that ran on every spine item. Navigation documents are now identified from the package (`properties="nav"`, guide `toc`). Image-only pages (covers, plates, fixed layout) and SVG spine documents are kept. Fixes #1489.

## Process abort

A chapter nested about 30,000 elements deep overflowed the stack in the text walk and ended the process. The walk stops at the configured depth limit. Fixes #1490.

## Whole-book failures and silent drops

One spine item with an unsafe href failed the whole book. It is skipped with a warning like the sibling failures. Markdown conversion warnings are now reported, and the iteration limit names the items it skipped. Fixes #1491.

## Metadata

Every Dublin Core element was last-wins: the subtitle replaced the title, the illustrator replaced the author, the modification date replaced the publication date. Elements are matched by namespace; all creators and subjects are kept; the EPUB 3 `cover-image` property is honoured and a cover reference that points at an XHTML page is ignored. Fixes #1492.

## Rendering

Nested tables no longer erase the enclosing table; `<br>` in headings no longer leaks U+0001; the serialised MathML comment is stripped from Markdown output; an unresolved image keeps its alt text in plain output. Fixes #1493.

## Encoding and DRM

Members declared in a non-UTF-8 encoding or written in UTF-16 are decoded. `META-INF/encryption.xml` is read; DRM-encrypted spine items are skipped with one warning, and font obfuscation alone does not warn. Fixes #1494.

## Media types

Spine items labelled `text/html` (every Internet Archive EPUB), `text/xml`, `application/xml`, or with parameters, uppercase, or an empty attribute were skipped. The media type is normalised before matching. Supersedes #1487. Fixes #1486.
