### PR TITLE
ci: skip pull request workflows for draft PRs

### DIFF
--- a/.github/workflows/ci-docker.yaml
+++ b/.github/workflows/ci-docker.yaml
@@ -11,6 +11,7 @@ on:
       - "crates/xberg-cli/Cargo.toml"
       - ".github/workflows/ci-docker.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths: *docker-paths
   workflow_dispatch:
@@ -29,7 +30,7 @@ permissions:
 jobs:
   docker:
     name: Docker (${{ matrix.variant }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -8,6 +8,7 @@ on:
       - "alef.toml"
       - ".github/workflows/ci-docs.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "docs-site/**"
@@ -26,6 +27,7 @@ concurrency:
 
 jobs:
   docs:
+    if: github.event.pull_request.draft != true
     uses: xberg-io/actions/.github/workflows/reusable-docs-deploy.yml@v1
     with:
       deploy: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -16,6 +16,7 @@ on:
       - "scripts/ci/wasm/**"
       - ".github/workflows/ci-e2e.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "crates/**"
@@ -53,7 +54,7 @@ permissions:
 jobs:
   build-ffi:
     name: Build FFI (${{ matrix.target }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     strategy:
@@ -144,7 +145,7 @@ jobs:
 
   e2e-tests:
     name: E2E (${{ matrix.lang }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     needs: [build-ffi]
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 180

--- a/.github/workflows/ci-integrations.yaml
+++ b/.github/workflows/ci-integrations.yaml
@@ -26,6 +26,7 @@ on:
       - "scripts/ci/actions/setup-onnx-runtime/**"
       - ".github/workflows/ci-integrations.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "integrations/**"
@@ -72,7 +73,7 @@ permissions:
 jobs:
   build-bindings:
     name: Build local integration bindings
-    if: github.repository == 'xberg-io/xberg'
+    if: github.repository == 'xberg-io/xberg' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -155,7 +156,7 @@ jobs:
 
   python:
     name: Python (py${{ matrix.python }})
-    if: github.repository == 'xberg-io/xberg'
+    if: github.repository == 'xberg-io/xberg' && github.event.pull_request.draft != true
     needs: [build-bindings]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -199,7 +200,7 @@ jobs:
 
   node:
     name: Node
-    if: github.repository == 'xberg-io/xberg'
+    if: github.repository == 'xberg-io/xberg' && github.event.pull_request.draft != true
     needs: [build-bindings]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -244,7 +245,7 @@ jobs:
 
   java:
     name: Java (spring-ai)
-    if: github.repository == 'xberg-io/xberg'
+    if: github.repository == 'xberg-io/xberg' && github.event.pull_request.draft != true
     needs: [build-bindings]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -25,6 +25,7 @@ on:
       - ".agents/plugins/**"
       - "test_documents"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "crates/**"
@@ -58,6 +59,7 @@ permissions:
 
 jobs:
   benchmark-scripts:
+    if: github.event.pull_request.draft != true
     name: Benchmark script regressions
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +70,7 @@ jobs:
         run: task benchmark:validate:scripts
 
   plugin-freshness:
+    if: github.event.pull_request.draft != true
     name: Plugin bundle freshness
     runs-on: ubuntu-latest
     steps:
@@ -87,6 +90,7 @@ jobs:
         run: uvx ai-rulez==4.11.0 verify --recursive --plugin --if-configured
 
   submodule-gitlinks:
+    if: github.event.pull_request.draft != true
     name: Submodule gitlinks reachable
     runs-on: ubuntu-latest
     steps:
@@ -104,6 +108,7 @@ jobs:
         run: scripts/ci/check-submodule-gitlinks.sh --on-fetch-failure=fail
 
   alef-readme-paths:
+    if: github.event.pull_request.draft != true
     name: Alef readme/docs paths resolve
     runs-on: ubuntu-latest
     steps:
@@ -152,6 +157,7 @@ jobs:
         run: task docs:verify:changelog
 
   alef-bindings-freshness:
+    if: github.event.pull_request.draft != true
     name: Alef-generated bindings freshness
     runs-on: ubuntu-latest
     steps:
@@ -219,6 +225,7 @@ jobs:
         run: task alef:verify
 
   e2e-freshness:
+    if: github.event.pull_request.draft != true
     name: Generated e2e suites freshness
     runs-on: ubuntu-latest
     steps:
@@ -291,6 +298,7 @@ jobs:
         run: task e2e:verify
 
   docs-snippets:
+    if: github.event.pull_request.draft != true
     name: Docs snippets gate
     runs-on: ubuntu-latest
     steps:
@@ -357,6 +365,7 @@ jobs:
         run: task docs:snippets:all
 
   validate:
+    if: github.event.pull_request.draft != true
     uses: xberg-io/actions/.github/workflows/reusable-validate.yml@v1
     with:
       # Left empty, the reusable workflow asks the GitHub API for the newest poly

--- a/.github/workflows/ci-mobile.yaml
+++ b/.github/workflows/ci-mobile.yaml
@@ -15,6 +15,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci-mobile.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "crates/xberg/**"
@@ -46,7 +47,7 @@ permissions:
 jobs:
   android-check:
     name: Android cargo check (${{ matrix.abi }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -67,7 +68,7 @@ jobs:
 
   ios-check:
     name: iOS cargo check (${{ matrix.target }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: macos-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ci-musl-csharp.yaml
+++ b/.github/workflows/ci-musl-csharp.yaml
@@ -36,6 +36,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci-musl-csharp.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths: *musl-csharp-paths
   schedule:
@@ -54,7 +55,7 @@ permissions:
 jobs:
   musl-csharp-native:
     name: Build + smoke-test C# native (linux-musl-${{ matrix.arch }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci-musl-elixir.yaml
+++ b/.github/workflows/ci-musl-elixir.yaml
@@ -38,6 +38,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci-musl-elixir.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths: *musl-elixir-paths
   schedule:
@@ -56,7 +57,7 @@ permissions:
 jobs:
   musl-elixir-nif:
     name: Build + smoke-test Elixir NIF (linux-musl-${{ matrix.arch }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/ci-musl-java.yaml
+++ b/.github/workflows/ci-musl-java.yaml
@@ -35,6 +35,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci-musl-java.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths: *musl-java-paths
   schedule:
@@ -53,7 +54,7 @@ permissions:
 jobs:
   musl-java-native:
     name: Build + smoke-test Java native (linux-musl-${{ matrix.arch }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci-musl-node.yaml
+++ b/.github/workflows/ci-musl-node.yaml
@@ -33,6 +33,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci-musl-node.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths: *musl-node-paths
   schedule:
@@ -51,7 +52,7 @@ permissions:
 jobs:
   musl-node-binding:
     name: Build + smoke-test Node binding (linux-musl-${{ matrix.arch }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci-musl-python.yaml
+++ b/.github/workflows/ci-musl-python.yaml
@@ -42,6 +42,7 @@ on:
       - "Cargo.lock"
       - ".github/workflows/ci-musl-python.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths: *musl-python-paths
   schedule:
@@ -60,7 +61,7 @@ permissions:
 jobs:
   musl-python-wheel:
     name: Build + smoke-test Python wheel (musl-${{ matrix.arch }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -18,6 +18,7 @@ on:
       # pin bump changes what this workflow actually verifies. ~keep
       - "test_documents"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths:
       - "crates/**"
@@ -56,7 +57,7 @@ permissions:
 jobs:
   rust:
     name: Rust (${{ matrix.os }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
@@ -265,7 +266,7 @@ jobs:
   # time actually running the (fixture-heavy) test suite. ~keep
   windows-static-embeddings-link:
     name: Rust (windows-latest, static-embeddings link)
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -303,7 +304,7 @@ jobs:
   # Also the only job that builds/tests xberg-libwpd on Windows.
   clippy-windows:
     name: Rust (windows-latest)
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -360,7 +361,7 @@ jobs:
   # CI time for no new coverage. ~keep
   rust-tract-no-ort:
     name: Rust tract-only (no-ORT)
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     env:
@@ -452,7 +453,7 @@ jobs:
   # reuse each other's dependency graph, on cached sccache artifacts.
   narrow-feature-legs:
     name: Narrow feature leg (${{ matrix.name }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -493,7 +494,7 @@ jobs:
   # tesseract-wasm's C sources against it, same as publish.yaml's wasm-bindings job).
   wasm-target-check:
     name: Narrow feature leg (wasm-target, wasm32)
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -534,7 +535,7 @@ jobs:
   # introspection with no include_bytes! fixtures, so no test_documents fetch is needed.
   xberg-cli-feature-legs:
     name: xberg-cli feature leg (${{ matrix.name }})
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -649,7 +650,7 @@ jobs:
   # copy anywhere. ~keep
   pdfium-engine:
     name: Rust pdfium engine (real library)
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -698,7 +699,7 @@ jobs:
 
   live-hf:
     name: Live HF preset tests
-    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]' && github.event.pull_request.draft != true
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -2,7 +2,8 @@ name: Validate PR
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    branches: [main]
 
 permissions:
   contents: read
@@ -11,5 +12,6 @@ permissions:
 
 jobs:
   validate:
+    if: github.event.pull_request.draft != true
     uses: xberg-io/actions/.github/workflows/reusable-validate-pr.yml@v1
     secrets: inherit


### PR DESCRIPTION
Closes #1500.

## Draft gate

Every job in the 13 `pull_request` workflows now carries `github.event.pull_request.draft != true` in its `if`. Jobs that already had a repository or dependabot condition get it appended. `push` runs on `main` are unaffected because the expression is true when there is no pull request in the event.

## Trigger types

Each `pull_request` block now lists `types: [opened, synchronize, reopened, ready_for_review]`. Without `ready_for_review`, marking a draft ready would not start CI until the next push.

## Target branch

`validate-pr.yml` gains `branches: [main]`; the other 12 workflows already had it.