### PR TITLE
fix(security): pin Tesseract native inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12268,6 +12268,7 @@ dependencies = [
  "image 0.25.10",
  "pkg-config",
  "reqwest",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "vcpkg",
  "zip 8.6.0",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -85,3 +85,22 @@ platform's `libheif` build links it.
   `reranker`, `auto-rotate`, transcription). License: MIT. Linked dynamically
   (system `libonnxruntime.so`) in the musl/container builds; bundled per the
   `ort-bundled` feature (official Microsoft binaries) otherwise.
+
+## Tesseract OCR + Leptonica
+
+- **Feature:** `xberg-tesseract` builds Tesseract 5.5.3 at commit
+  `db0ec62f81b0737fbbe184d8fea40af5738f8eef` and Leptonica 1.87.0 at commit
+  `13275a278eb55b5746e33f95fbf5a2c8f604b3ab` when `build-tesseract` or
+  `build-tesseract-wasm` is enabled.
+- **Licenses:** Tesseract is Apache-2.0; the exact upstream text is preserved in
+  [`crates/xberg-tesseract/licenses/tesseract-LICENSE`](crates/xberg-tesseract/licenses/tesseract-LICENSE).
+  Leptonica is BSD-2-Clause; the exact upstream notice is preserved in
+  [`crates/xberg-tesseract/licenses/leptonica-LICENSE`](crates/xberg-tesseract/licenses/leptonica-LICENSE).
+- **Linking:** both native libraries are built from their checksum-verified
+  source archives and statically linked into the consuming artifact. Their
+  permissive licenses permit static linking when the license texts and notices
+  accompany redistribution.
+- **Model redistribution:** `eng.traineddata` is redistributed from
+  `tessdata_fast` commit `87416418657359cb625c412a48b6e1d6d41c29bd` after
+  checksum verification. `tessdata_fast` uses the same Apache-2.0 license text
+  as Tesseract, so the preserved Tesseract license covers the model artifact.

--- a/crates/xberg-tesseract/Cargo.toml
+++ b/crates/xberg-tesseract/Cargo.toml
@@ -47,6 +47,7 @@ thiserror = { workspace = true }
 cc = { version = "^1.4.4", optional = true }
 cmake = { version = "0.1.58", optional = true }
 pkg-config = { version = "0.3.34", optional = true }
+sha2 = { workspace = true }
 vcpkg = { version = "0.2.15", optional = true }
 zip = { version = ">=7.0.0", optional = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
@@ -59,3 +60,4 @@ reqwest = { workspace = true, default-features = false, features = ["blocking", 
 
 [dev-dependencies]
 image = { workspace = true, features = ["png"] }
+sha2 = { workspace = true }

--- a/crates/xberg-tesseract/build.rs
+++ b/crates/xberg-tesseract/build.rs
@@ -16,49 +16,145 @@ mod source_cache;
     all(feature = "build-tesseract", not(feature = "dynamic-linking"))
 ))]
 mod build_tesseract {
-    use crate::source_cache::{PreparedSourceTree, prepare_source_tree, source_tree_is_complete};
+    use crate::source_cache::{
+        PreparedSourceTree, SourceArtifact, copy_verified_artifact, ensure_directory, prepare_source_tree,
+        prepare_verified_artifact,
+    };
     use cmake::Config;
     use std::env;
     use std::fs;
+    use std::io;
     use std::path::{Path, PathBuf};
 
     const LEPTONICA_VERSION: &str = "1.87.0";
+    const LEPTONICA_REVISION: &str = "13275a278eb55b5746e33f95fbf5a2c8f604b3ab";
+    const LEPTONICA_SHA256: &str = "0febcd4fc5cdc9c52d59509b45483d107f9f40922899e3f134ea615094ecbc77";
+    const LEPTONICA_ARCHIVE_SIZE: u64 = 14_348_280;
+    const LEPTONICA_ARCHIVE_ROOT: &str = "leptonica-13275a278eb55b5746e33f95fbf5a2c8f604b3ab";
+    const LEPTONICA_LICENSE_FILE: &str = "leptonica-license.txt";
     const TESSERACT_VERSION: &str = "5.5.3";
+    const TESSERACT_REVISION: &str = "db0ec62f81b0737fbbe184d8fea40af5738f8eef";
+    const TESSERACT_SHA256: &str = "d2470cc33ee34deeae6fc47809d0b33a3623a4343d92ff317ac3b9903c507bad";
+    const TESSERACT_ARCHIVE_SIZE: u64 = 2_533_335;
+    const TESSERACT_ARCHIVE_ROOT: &str = "tesseract-db0ec62f81b0737fbbe184d8fea40af5738f8eef";
+    const TESSERACT_LICENSE_FILE: &str = "LICENSE";
+    const TESSDATA_FAST_REVISION: &str = "87416418657359cb625c412a48b6e1d6d41c29bd";
+    const ENG_TRAINEDDATA_SHA256: &str = "7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2";
+    const ENG_TRAINEDDATA_SIZE: u64 = 4_113_088;
+    const MAX_SOURCE_ARCHIVE_ENTRIES: usize = 50_000;
+    const MAX_SOURCE_UNCOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
+
+    const LEPTONICA_ARTIFACT: SourceArtifact<'static> = SourceArtifact {
+        name: "leptonica.zip",
+        cache_key: "leptonica-source",
+        sha256: LEPTONICA_SHA256,
+    };
+    const TESSERACT_ARTIFACT: SourceArtifact<'static> = SourceArtifact {
+        name: "tesseract.zip",
+        cache_key: "tesseract-source",
+        sha256: TESSERACT_SHA256,
+    };
+    const ENG_TRAINEDDATA_ARTIFACT: SourceArtifact<'static> = SourceArtifact {
+        name: "eng.traineddata",
+        cache_key: "tessdata-fast-eng",
+        sha256: ENG_TRAINEDDATA_SHA256,
+    };
+
+    struct SourceArchiveSpec {
+        artifact: SourceArtifact<'static>,
+        source_name: &'static str,
+        archive_root: &'static str,
+        license_file: &'static str,
+        expected_size: u64,
+    }
+
+    const LEPTONICA_SOURCE: SourceArchiveSpec = SourceArchiveSpec {
+        artifact: LEPTONICA_ARTIFACT,
+        source_name: "leptonica",
+        archive_root: LEPTONICA_ARCHIVE_ROOT,
+        license_file: LEPTONICA_LICENSE_FILE,
+        expected_size: LEPTONICA_ARCHIVE_SIZE,
+    };
+    const TESSERACT_SOURCE: SourceArchiveSpec = SourceArchiveSpec {
+        artifact: TESSERACT_ARTIFACT,
+        source_name: "tesseract",
+        archive_root: TESSERACT_ARCHIVE_ROOT,
+        license_file: TESSERACT_LICENSE_FILE,
+        expected_size: TESSERACT_ARCHIVE_SIZE,
+    };
 
     fn leptonica_url() -> String {
         format!(
-            "https://codeload.github.com/DanBloomberg/leptonica/zip/refs/tags/{}",
-            LEPTONICA_VERSION
+            "https://codeload.github.com/DanBloomberg/leptonica/zip/{}",
+            LEPTONICA_REVISION
         )
     }
 
     fn tesseract_url() -> String {
         format!(
-            "https://codeload.github.com/tesseract-ocr/tesseract/zip/refs/tags/{}",
-            TESSERACT_VERSION
+            "https://codeload.github.com/tesseract-ocr/tesseract/zip/{}",
+            TESSERACT_REVISION
         )
     }
 
-    fn get_or_download_source(third_party_dir: &Path, url: &str, name: &str) -> PreparedSourceTree {
-        let source_dir = third_party_dir.join(name);
-        if source_dir.exists() && !source_tree_is_complete(&source_dir) {
-            println!(
-                "cargo:warning=Cached {} source at {} is incomplete (missing CMakeLists.txt); redownloading",
-                name,
-                source_dir.display()
+    fn tessdata_fast_urls() -> [String; 2] {
+        [
+            format!(
+                "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/{}/eng.traineddata",
+                TESSDATA_FAST_REVISION
+            ),
+            format!(
+                "https://github.com/tesseract-ocr/tessdata_fast/raw/{}/eng.traineddata",
+                TESSDATA_FAST_REVISION
+            ),
+        ]
+    }
+
+    fn get_or_download_source(
+        artifact_cache_dir: &Path,
+        third_party_dir: &Path,
+        source: &SourceArchiveSpec,
+        url: &str,
+    ) -> PreparedSourceTree {
+        let verified_archive = prepare_verified_artifact(artifact_cache_dir, &source.artifact, |destination| {
+            download_file_with_fallback(&[url], destination, source.source_name, source.expected_size)
+        })
+        .unwrap_or_else(|error| panic!("Failed to verify {} source archive: {error}", source.source_name));
+
+        let prepared = prepare_source_tree(
+            third_party_dir,
+            source.source_name,
+            &verified_archive,
+            |archive, destination| extract_source_archive(archive, destination, source.archive_root),
+        )
+        .unwrap_or_else(|error| panic!("Failed to prepare {} source: {error}", source.source_name));
+
+        if !prepared.path.join(source.license_file).is_file() {
+            panic!(
+                "Verified {} source is missing required license file {}",
+                source.source_name,
+                prepared.path.join(source.license_file).display()
             );
         }
 
-        let prepared = prepare_source_tree(third_party_dir, name, |download_dir| {
-            download_and_extract(download_dir, url, name);
-        })
-        .unwrap_or_else(|error| panic!("Failed to prepare {name} source: {error}"));
-
         if !prepared.downloaded {
-            eprintln!("Using existing {name} source");
+            eprintln!("Using verified cached {} archive", source.source_name);
         }
 
         prepared
+    }
+
+    fn prepare_eng_traineddata(artifact_cache_dir: &Path, destination: &Path) {
+        let urls = tessdata_fast_urls();
+        let url_refs = urls.iter().map(String::as_str).collect::<Vec<_>>();
+        let verified_model =
+            prepare_verified_artifact(artifact_cache_dir, &ENG_TRAINEDDATA_ARTIFACT, |temporary_path| {
+                download_file_with_fallback(&url_refs, temporary_path, "eng.traineddata", ENG_TRAINEDDATA_SIZE)
+            })
+            .unwrap_or_else(|error| panic!("Failed to verify eng.traineddata: {error}"));
+
+        copy_verified_artifact(&verified_model, destination)
+            .unwrap_or_else(|error| panic!("Failed to prepare bundled eng.traineddata: {error}"));
     }
 
     fn workspace_cache_dir_from_out_dir() -> Option<PathBuf> {
@@ -320,7 +416,7 @@ mod build_tesseract {
 
     fn prepare_out_dir() -> PathBuf {
         let preferred = get_preferred_out_dir();
-        match fs::create_dir_all(&preferred) {
+        match ensure_directory(&preferred) {
             Ok(_) => preferred,
             Err(err) => {
                 println!(
@@ -328,10 +424,14 @@ mod build_tesseract {
                     preferred, err
                 );
                 let fallback = env::temp_dir().join("xberg-tesseract-cache");
-                fs::create_dir_all(&fallback).expect("Failed to create fallback cache directory in temp dir");
+                ensure_directory(&fallback).expect("Failed to create fallback cache directory in temp dir");
                 fallback
             }
         }
+    }
+
+    fn cargo_build_root() -> PathBuf {
+        PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not set"))
     }
 
     /// Find the WASI SDK installation directory.
@@ -432,145 +532,142 @@ mod build_tesseract {
             return build_wasm();
         }
 
-        let custom_out_dir = prepare_out_dir();
+        let artifact_cache_dir = prepare_out_dir().join("source-artifacts");
+        let build_root = cargo_build_root();
         let windows_target = is_windows_target(&target);
         let msvc_target = is_msvc_target(&target);
         let mingw_target = is_mingw_target(&target);
         let android_target = is_android_target(&target);
 
-        eprintln!("custom_out_dir: {:?}", custom_out_dir);
+        eprintln!("build_root: {:?}", build_root);
 
-        let cache_dir = custom_out_dir.join("cache");
-
-        if env::var("CARGO_CLEAN").is_ok() {
-            clean_cache(&cache_dir);
-        }
-
-        std::fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
-
-        let out_dir = custom_out_dir.clone();
-        let project_dir = custom_out_dir.clone();
+        let out_dir = build_root.clone();
+        let project_dir = build_root.clone();
         let third_party_dir = project_dir.join("third_party");
 
-        let leptonica_dir = get_or_download_source(&third_party_dir, &leptonica_url(), "leptonica").path;
-        let tesseract_dir = get_or_download_source(&third_party_dir, &tesseract_url(), "tesseract").path;
+        let leptonica_dir = get_or_download_source(
+            &artifact_cache_dir,
+            &third_party_dir,
+            &LEPTONICA_SOURCE,
+            &leptonica_url(),
+        )
+        .path;
+        let tesseract_dir = get_or_download_source(
+            &artifact_cache_dir,
+            &third_party_dir,
+            &TESSERACT_SOURCE,
+            &tesseract_url(),
+        )
+        .path;
 
         let (cmake_cxx_flags, cmake_c_flags, additional_defines) = get_os_specific_config();
 
         let leptonica_install_dir = out_dir.join("leptonica");
-        let leptonica_cache_dir = cache_dir.join("leptonica");
+        let leptonica_link_name = build_static_library("leptonica", &leptonica_install_dir, || {
+            let mut leptonica_config = Config::new(&leptonica_dir);
 
-        let leptonica_link_name = build_or_use_cached(
-            "leptonica",
-            &leptonica_cache_dir,
-            &leptonica_install_dir,
-            || {
-                let mut leptonica_config = Config::new(&leptonica_dir);
+            let leptonica_src_dir = leptonica_dir.join("src");
+            let environ_h_path = leptonica_src_dir.join("environ.h");
 
-                let leptonica_src_dir = leptonica_dir.join("src");
-                let environ_h_path = leptonica_src_dir.join("environ.h");
+            if environ_h_path.exists() {
+                let environ_h = std::fs::read_to_string(&environ_h_path)
+                    .expect("Failed to read environ.h")
+                    .replace("#define  HAVE_LIBZ          1", "#define  HAVE_LIBZ          0")
+                    .replace("#ifdef  NO_CONSOLE_IO", "#define NO_CONSOLE_IO\n#ifdef  NO_CONSOLE_IO");
+                std::fs::write(environ_h_path, environ_h).expect("Failed to write environ.h");
+            }
 
-                if environ_h_path.exists() {
-                    let environ_h = std::fs::read_to_string(&environ_h_path)
-                        .expect("Failed to read environ.h")
-                        .replace("#define  HAVE_LIBZ          1", "#define  HAVE_LIBZ          0")
-                        .replace("#ifdef  NO_CONSOLE_IO", "#define NO_CONSOLE_IO\n#ifdef  NO_CONSOLE_IO");
-                    std::fs::write(environ_h_path, environ_h).expect("Failed to write environ.h");
-                }
+            let makefile_static_path = leptonica_dir.join("prog").join("makefile.static");
 
-                let makefile_static_path = leptonica_dir.join("prog").join("makefile.static");
+            let leptonica_src_cmakelists = leptonica_dir.join("src").join("CMakeLists.txt");
 
-                let leptonica_src_cmakelists = leptonica_dir.join("src").join("CMakeLists.txt");
-
-                if leptonica_src_cmakelists.exists() {
-                    let cmakelists = std::fs::read_to_string(&leptonica_src_cmakelists)
-                        .expect("Failed to read leptonica src CMakeLists.txt");
-                    let patched = cmakelists.replace(
+            if leptonica_src_cmakelists.exists() {
+                let cmakelists = std::fs::read_to_string(&leptonica_src_cmakelists)
+                    .expect("Failed to read leptonica src CMakeLists.txt");
+                let patched = cmakelists.replace(
                         "if(MINGW)\n  set_target_properties(\n    leptonica PROPERTIES SUFFIX\n                         \"-${PROJECT_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}\")\nendif(MINGW)\n",
                         "if(MINGW AND BUILD_SHARED_LIBS)\n  set_target_properties(\n    leptonica PROPERTIES SUFFIX\n                         \"-${PROJECT_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}\")\nendif()\n",
                     );
-                    if patched != cmakelists {
-                        std::fs::write(&leptonica_src_cmakelists, patched)
-                            .expect("Failed to patch leptonica src CMakeLists.txt");
-                    }
+                if patched != cmakelists {
+                    std::fs::write(&leptonica_src_cmakelists, patched)
+                        .expect("Failed to patch leptonica src CMakeLists.txt");
                 }
+            }
 
-                if makefile_static_path.exists() {
-                    let makefile_static = std::fs::read_to_string(&makefile_static_path)
-                        .expect("Failed to read makefile.static")
-                        .replace(
-                            "ALL_LIBS =	$(LEPTLIB) -ltiff -ljpeg -lpng -lz -lm",
-                            "ALL_LIBS =	$(LEPTLIB) -lm",
-                        );
-                    std::fs::write(makefile_static_path, makefile_static).expect("Failed to write makefile.static");
+            if makefile_static_path.exists() {
+                let makefile_static = std::fs::read_to_string(&makefile_static_path)
+                    .expect("Failed to read makefile.static")
+                    .replace(
+                        "ALL_LIBS =	$(LEPTLIB) -ltiff -ljpeg -lpng -lz -lm",
+                        "ALL_LIBS =	$(LEPTLIB) -lm",
+                    );
+                std::fs::write(makefile_static_path, makefile_static).expect("Failed to write makefile.static");
+            }
+
+            if windows_target {
+                if mingw_target {
+                    leptonica_config.generator("Unix Makefiles");
+                    leptonica_config.define("CMAKE_MAKE_PROGRAM", "mingw32-make");
+                    leptonica_config.define("MSYS2_ARG_CONV_EXCL", "/MD;/MDd;/D;-D;-I;-L");
+                } else if msvc_target && env::var("VSINSTALLDIR").is_ok() {
+                    leptonica_config.generator("NMake Makefiles");
                 }
+                leptonica_config.define("CMAKE_CL_SHOWINCLUDES_PREFIX", "");
+            }
 
-                if windows_target {
-                    if mingw_target {
-                        leptonica_config.generator("Unix Makefiles");
-                        leptonica_config.define("CMAKE_MAKE_PROGRAM", "mingw32-make");
-                        leptonica_config.define("MSYS2_ARG_CONV_EXCL", "/MD;/MDd;/D;-D;-I;-L");
-                    } else if msvc_target && env::var("VSINSTALLDIR").is_ok() {
-                        leptonica_config.generator("NMake Makefiles");
-                    }
-                    leptonica_config.define("CMAKE_CL_SHOWINCLUDES_PREFIX", "");
+            if env::var("CI").is_err() && env::var("RUSTC_WRAPPER").unwrap_or_default() == "sccache" {
+                leptonica_config.env("CC", "sccache cc").env("CXX", "sccache c++");
+            }
+
+            let leptonica_install_dir_cmake = normalize_cmake_path(&leptonica_install_dir);
+
+            leptonica_config
+                .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+                .define("CMAKE_BUILD_TYPE", "Release")
+                .define("BUILD_PROG", "OFF")
+                .define("BUILD_SHARED_LIBS", "OFF")
+                .define("ENABLE_ZLIB", "OFF")
+                .define("ENABLE_PNG", "OFF")
+                .define("ENABLE_JPEG", "OFF")
+                .define("ENABLE_TIFF", "OFF")
+                .define("ENABLE_WEBP", "OFF")
+                .define("ENABLE_OPENJPEG", "OFF")
+                .define("ENABLE_GIF", "OFF")
+                .define("NO_CONSOLE_IO", "ON")
+                .define("CMAKE_CXX_FLAGS", &cmake_cxx_flags)
+                .define("CMAKE_C_FLAGS", &cmake_c_flags)
+                .define("MINIMUM_SEVERITY", "L_SEVERITY_NONE")
+                .define("SW_BUILD", "OFF")
+                .define("HAVE_LIBZ", "0")
+                .define("ENABLE_LTO", "OFF")
+                .define("CMAKE_INSTALL_PREFIX", &leptonica_install_dir_cmake);
+
+            if windows_target {
+                if msvc_target {
+                    leptonica_config
+                        .define("CMAKE_C_FLAGS_RELEASE", "/MD /O2")
+                        .define("CMAKE_C_FLAGS_DEBUG", "/MDd /Od");
+                } else if mingw_target {
+                    leptonica_config
+                        .define("CMAKE_C_FLAGS_RELEASE", "-O2 -DNDEBUG")
+                        .define("CMAKE_C_FLAGS_DEBUG", "-O0 -g");
+                } else {
+                    leptonica_config
+                        .define("CMAKE_C_FLAGS_RELEASE", "-O2")
+                        .define("CMAKE_C_FLAGS_DEBUG", "-O0 -g");
                 }
+            }
 
-                if env::var("CI").is_err() && env::var("RUSTC_WRAPPER").unwrap_or_default() == "sccache" {
-                    leptonica_config.env("CC", "sccache cc").env("CXX", "sccache c++");
-                }
+            for (key, value) in &additional_defines {
+                leptonica_config.define(key, value);
+            }
 
-                let leptonica_install_dir_cmake = normalize_cmake_path(&leptonica_install_dir);
-
-                leptonica_config
-                    .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
-                    .define("CMAKE_BUILD_TYPE", "Release")
-                    .define("BUILD_PROG", "OFF")
-                    .define("BUILD_SHARED_LIBS", "OFF")
-                    .define("ENABLE_ZLIB", "OFF")
-                    .define("ENABLE_PNG", "OFF")
-                    .define("ENABLE_JPEG", "OFF")
-                    .define("ENABLE_TIFF", "OFF")
-                    .define("ENABLE_WEBP", "OFF")
-                    .define("ENABLE_OPENJPEG", "OFF")
-                    .define("ENABLE_GIF", "OFF")
-                    .define("NO_CONSOLE_IO", "ON")
-                    .define("CMAKE_CXX_FLAGS", &cmake_cxx_flags)
-                    .define("CMAKE_C_FLAGS", &cmake_c_flags)
-                    .define("MINIMUM_SEVERITY", "L_SEVERITY_NONE")
-                    .define("SW_BUILD", "OFF")
-                    .define("HAVE_LIBZ", "0")
-                    .define("ENABLE_LTO", "OFF")
-                    .define("CMAKE_INSTALL_PREFIX", &leptonica_install_dir_cmake);
-
-                if windows_target {
-                    if msvc_target {
-                        leptonica_config
-                            .define("CMAKE_C_FLAGS_RELEASE", "/MD /O2")
-                            .define("CMAKE_C_FLAGS_DEBUG", "/MDd /Od");
-                    } else if mingw_target {
-                        leptonica_config
-                            .define("CMAKE_C_FLAGS_RELEASE", "-O2 -DNDEBUG")
-                            .define("CMAKE_C_FLAGS_DEBUG", "-O0 -g");
-                    } else {
-                        leptonica_config
-                            .define("CMAKE_C_FLAGS_RELEASE", "-O2")
-                            .define("CMAKE_C_FLAGS_DEBUG", "-O0 -g");
-                    }
-                }
-
-                for (key, value) in &additional_defines {
-                    leptonica_config.define(key, value);
-                }
-
-                leptonica_config.build();
-            },
-        );
+            leptonica_config.build();
+        });
 
         let leptonica_include_dir = leptonica_install_dir.join("include");
         let leptonica_lib_dir = leptonica_install_dir.join("lib");
         let tesseract_install_dir = out_dir.join("tesseract");
-        let tesseract_cache_dir = cache_dir.join("tesseract");
         let tessdata_prefix = project_dir.clone();
 
         let leptonica_install_dir_cmake = normalize_cmake_path(&leptonica_install_dir);
@@ -581,14 +678,13 @@ mod build_tesseract {
         let tesseract_install_dir_cmake = normalize_cmake_path(&tesseract_install_dir);
         let tessdata_prefix_cmake = normalize_cmake_path(&tessdata_prefix);
 
-        let tesseract_link_name =
-            build_or_use_cached("tesseract", &tesseract_cache_dir, &tesseract_install_dir, || {
-                let cmakelists_path = tesseract_dir.join("CMakeLists.txt");
-                let cmakelists = std::fs::read_to_string(&cmakelists_path)
-                    .expect("Failed to read CMakeLists.txt")
-                    .replace("set(HAVE_TIFFIO_H ON)", "")
-                    .replace(
-                        "add_executable(tesseract src/tesseract.cpp)\n\
+        let tesseract_link_name = build_static_library("tesseract", &tesseract_install_dir, || {
+            let cmakelists_path = tesseract_dir.join("CMakeLists.txt");
+            let cmakelists = std::fs::read_to_string(&cmakelists_path)
+                .expect("Failed to read CMakeLists.txt")
+                .replace("set(HAVE_TIFFIO_H ON)", "")
+                .replace(
+                    "add_executable(tesseract src/tesseract.cpp)\n\
                          target_link_libraries(tesseract libtesseract)\n\
                          if(HAVE_TIFFIO_H AND WIN32)\n\
                          \x20 target_link_libraries(tesseract ${TIFF_LIBRARIES})\n\
@@ -597,19 +693,19 @@ mod build_tesseract {
                          if(OPENMP_BUILD AND UNIX)\n\
                          \x20 target_link_libraries(tesseract pthread)\n\
                          endif()",
-                        "",
-                    )
-                    .replace("install(TARGETS tesseract DESTINATION bin)", "")
-                    .replace(
-                        "if (MSVC)\n\
+                    "",
+                )
+                .replace("install(TARGETS tesseract DESTINATION bin)", "")
+                .replace(
+                    "if (MSVC)\n\
                          \x20 install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)\n\
                          endif()",
-                        "",
-                    );
+                    "",
+                );
 
-                let cmakelists = if android_target {
-                    cmakelists.replace(
-                        "if(ANDROID)\n\
+            let cmakelists = if android_target {
+                cmakelists.replace(
+                    "if(ANDROID)\n\
                          \x20 add_definitions(-DANDROID)\n\
                          \x20 find_package(CpuFeaturesNdkCompat REQUIRED)\n\
                          \x20 target_include_directories(\n\
@@ -617,105 +713,93 @@ mod build_tesseract {
                          \x20\x20\x20 PRIVATE \"${CpuFeaturesNdkCompat_DIR}/../../../include/ndk_compat\")\n\
                          \x20 target_link_libraries(libtesseract PRIVATE CpuFeatures::ndk_compat)\n\
                          endif()",
-                        "if(ANDROID)\n\
+                    "if(ANDROID)\n\
                          \x20 add_definitions(-DANDROID)\n\
                          endif()",
-                    )
-                } else {
-                    cmakelists
-                };
+                )
+            } else {
+                cmakelists
+            };
 
-                std::fs::write(&cmakelists_path, cmakelists).expect("Failed to write CMakeLists.txt");
+            std::fs::write(&cmakelists_path, cmakelists).expect("Failed to write CMakeLists.txt");
 
-                let mut tesseract_config = Config::new(&tesseract_dir);
-                if windows_target {
-                    if mingw_target {
-                        tesseract_config.generator("Unix Makefiles");
-                        tesseract_config.define("CMAKE_MAKE_PROGRAM", "mingw32-make");
-                        tesseract_config.define("MSYS2_ARG_CONV_EXCL", "/MD;/MDd;/D;-D;-I;-L");
-                    } else if msvc_target && env::var("VSINSTALLDIR").is_ok() {
-                        tesseract_config.generator("NMake Makefiles");
-                    }
-                    tesseract_config.define("CMAKE_CL_SHOWINCLUDES_PREFIX", "");
+            let mut tesseract_config = Config::new(&tesseract_dir);
+            if windows_target {
+                if mingw_target {
+                    tesseract_config.generator("Unix Makefiles");
+                    tesseract_config.define("CMAKE_MAKE_PROGRAM", "mingw32-make");
+                    tesseract_config.define("MSYS2_ARG_CONV_EXCL", "/MD;/MDd;/D;-D;-I;-L");
+                } else if msvc_target && env::var("VSINSTALLDIR").is_ok() {
+                    tesseract_config.generator("NMake Makefiles");
                 }
+                tesseract_config.define("CMAKE_CL_SHOWINCLUDES_PREFIX", "");
+            }
 
-                if env::var("CI").is_err() && env::var("RUSTC_WRAPPER").unwrap_or_default() == "sccache" {
-                    tesseract_config.env("CC", "sccache cc").env("CXX", "sccache c++");
-                }
-                tesseract_config
-                    .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
-                    .define("CMAKE_BUILD_TYPE", "Release")
-                    .define("BUILD_TRAINING_TOOLS", "OFF")
-                    .define("BUILD_SHARED_LIBS", "OFF")
-                    .define("DISABLE_ARCHIVE", "ON")
-                    .define("DISABLE_CURL", "ON")
-                    .define("DISABLE_OPENCL", "ON")
-                    .define("Leptonica_DIR", &leptonica_cmake_dir_cmake)
-                    .define("LEPTONICA_INCLUDE_DIR", &leptonica_include_dir_cmake)
-                    .define("LEPTONICA_LIBRARY", &leptonica_lib_dir_cmake)
-                    .define("CMAKE_PREFIX_PATH", &leptonica_install_dir_cmake)
-                    .define("CMAKE_INSTALL_PREFIX", &tesseract_install_dir_cmake)
-                    .define("TESSDATA_PREFIX", &tessdata_prefix_cmake)
-                    .define("DISABLE_TIFF", "ON")
-                    .define("DISABLE_PNG", "ON")
-                    .define("DISABLE_JPEG", "ON")
-                    .define("DISABLE_WEBP", "ON")
-                    .define("DISABLE_OPENJPEG", "ON")
-                    .define("DISABLE_ZLIB", "ON")
-                    .define("DISABLE_LIBXML2", "ON")
-                    .define("DISABLE_LIBICU", "ON")
-                    .define("DISABLE_LZMA", "ON")
-                    .define("DISABLE_GIF", "ON")
-                    .define("DISABLE_DEBUG_MESSAGES", "ON")
-                    .define("debug_file", "/dev/null")
-                    .define("HAVE_LIBARCHIVE", "OFF")
-                    .define("HAVE_LIBCURL", "OFF")
-                    .define("HAVE_TIFFIO_H", "OFF")
-                    .define("GRAPHICS_DISABLED", "ON")
-                    .define("DISABLED_LEGACY_ENGINE", "OFF")
-                    .define("USE_OPENCL", "OFF")
-                    .define("OPENMP_BUILD", "OFF")
-                    .define("BUILD_TESTS", "OFF")
-                    .define("ENABLE_LTO", "OFF")
-                    .define("BUILD_PROG", "OFF")
-                    .define("BUILD_TESSERACT_BINARY", "OFF")
-                    .define("SW_BUILD", "OFF")
-                    .define("LEPT_TIFF_RESULT", "FALSE")
-                    .define("INSTALL_CONFIGS", "ON")
-                    .define("USE_SYSTEM_ICU", "ON")
-                    .define("CMAKE_CXX_FLAGS", &cmake_cxx_flags)
-                    .define("CMAKE_C_FLAGS", &cmake_c_flags);
+            if env::var("CI").is_err() && env::var("RUSTC_WRAPPER").unwrap_or_default() == "sccache" {
+                tesseract_config.env("CC", "sccache cc").env("CXX", "sccache c++");
+            }
+            tesseract_config
+                .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+                .define("CMAKE_BUILD_TYPE", "Release")
+                .define("BUILD_TRAINING_TOOLS", "OFF")
+                .define("BUILD_SHARED_LIBS", "OFF")
+                .define("DISABLE_ARCHIVE", "ON")
+                .define("DISABLE_CURL", "ON")
+                .define("DISABLE_OPENCL", "ON")
+                .define("Leptonica_DIR", &leptonica_cmake_dir_cmake)
+                .define("LEPTONICA_INCLUDE_DIR", &leptonica_include_dir_cmake)
+                .define("LEPTONICA_LIBRARY", &leptonica_lib_dir_cmake)
+                .define("CMAKE_PREFIX_PATH", &leptonica_install_dir_cmake)
+                .define("CMAKE_INSTALL_PREFIX", &tesseract_install_dir_cmake)
+                .define("TESSDATA_PREFIX", &tessdata_prefix_cmake)
+                .define("DISABLE_TIFF", "ON")
+                .define("DISABLE_PNG", "ON")
+                .define("DISABLE_JPEG", "ON")
+                .define("DISABLE_WEBP", "ON")
+                .define("DISABLE_OPENJPEG", "ON")
+                .define("DISABLE_ZLIB", "ON")
+                .define("DISABLE_LIBXML2", "ON")
+                .define("DISABLE_LIBICU", "ON")
+                .define("DISABLE_LZMA", "ON")
+                .define("DISABLE_GIF", "ON")
+                .define("DISABLE_DEBUG_MESSAGES", "ON")
+                .define("debug_file", "/dev/null")
+                .define("HAVE_LIBARCHIVE", "OFF")
+                .define("HAVE_LIBCURL", "OFF")
+                .define("HAVE_TIFFIO_H", "OFF")
+                .define("GRAPHICS_DISABLED", "ON")
+                .define("DISABLED_LEGACY_ENGINE", "OFF")
+                .define("USE_OPENCL", "OFF")
+                .define("OPENMP_BUILD", "OFF")
+                .define("BUILD_TESTS", "OFF")
+                .define("ENABLE_LTO", "OFF")
+                .define("BUILD_PROG", "OFF")
+                .define("BUILD_TESSERACT_BINARY", "OFF")
+                .define("SW_BUILD", "OFF")
+                .define("LEPT_TIFF_RESULT", "FALSE")
+                .define("INSTALL_CONFIGS", "ON")
+                .define("USE_SYSTEM_ICU", "ON")
+                .define("CMAKE_CXX_FLAGS", &cmake_cxx_flags)
+                .define("CMAKE_C_FLAGS", &cmake_c_flags);
 
-                if is_zigbuild() {
-                    tesseract_config.define("HAVE_AVX512F", "OFF");
-                }
+            if is_zigbuild() {
+                tesseract_config.define("HAVE_AVX512F", "OFF");
+            }
 
-                for (key, value) in &additional_defines {
-                    tesseract_config.define(key, value);
-                }
+            for (key, value) in &additional_defines {
+                tesseract_config.define(key, value);
+            }
 
-                tesseract_config.build();
-            });
+            tesseract_config.build();
+        });
 
         let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
         let eng_traineddata = PathBuf::from(&out_dir).join("eng.traineddata");
-        if !eng_traineddata.exists() {
-            download_file_with_fallback(
-                &[
-                    "https://github.com/tesseract-ocr/tessdata_fast/raw/main/eng.traineddata",
-                    "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/main/eng.traineddata",
-                ],
-                &eng_traineddata,
-                "eng.traineddata",
-            );
-        }
+        prepare_eng_traineddata(&artifact_cache_dir, &eng_traineddata);
         eprintln!("Bundled eng.traineddata: {:?}", eng_traineddata);
 
         println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rerun-if-changed=src/shim.cpp");
-        println!("cargo:rerun-if-changed={}", third_party_dir.display());
-        println!("cargo:rerun-if-changed={}", leptonica_dir.display());
-        println!("cargo:rerun-if-changed={}", tesseract_dir.display());
 
         #[cfg(feature = "build-tesseract")]
         cc::Build::new()
@@ -929,109 +1013,97 @@ mod build_tesseract {
         println!("cargo:rustc-link-search=native={}", env::var("OUT_DIR").unwrap());
     }
 
-    fn download_and_extract(target_dir: &Path, url: &str, name: &str) -> PathBuf {
+    fn extract_source_archive(bytes: &[u8], destination: &Path, expected_root: &str) -> io::Result<()> {
         use zip::ZipArchive;
 
-        fs::create_dir_all(target_dir).expect("Failed to create target directory");
+        let reader = std::io::Cursor::new(bytes);
+        let mut archive = ZipArchive::new(reader).map_err(invalid_archive)?;
+        if archive.len() > MAX_SOURCE_ARCHIVE_ENTRIES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "source archive contains {} entries, exceeding limit {MAX_SOURCE_ARCHIVE_ENTRIES}",
+                    archive.len()
+                ),
+            ));
+        }
 
-        let client = reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(300))
-            .http1_only()
-            .build()
-            .expect("Failed to create HTTP client");
-
-        eprintln!("Downloading {} from {}", name, url);
-        let max_attempts = 5;
-        let mut content = None;
-
-        for attempt in 1..=max_attempts {
-            let err_msg = match client.get(url).send() {
-                Ok(resp) => {
-                    if resp.status().is_success() {
-                        match resp.bytes() {
-                            Ok(bytes) => {
-                                content = Some(bytes.to_vec());
-                                break;
-                            }
-                            Err(err) => format!("Failed to read response: {}", err),
-                        }
-                    } else {
-                        format!("HTTP {}", resp.status().as_u16())
-                    }
-                }
-                Err(err) => err.to_string(),
-            };
-
-            if attempt == max_attempts {
-                panic!(
-                    "Failed to download {} after {} attempts: {}",
-                    name, max_attempts, err_msg
-                );
+        fs::create_dir_all(destination)?;
+        let mut uncompressed_bytes = 0_u64;
+        for index in 0..archive.len() {
+            let mut file = archive.by_index(index).map_err(invalid_archive)?;
+            uncompressed_bytes = uncompressed_bytes
+                .checked_add(file.size())
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "source archive size overflow"))?;
+            if uncompressed_bytes > MAX_SOURCE_UNCOMPRESSED_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("source archive expands beyond {MAX_SOURCE_UNCOMPRESSED_BYTES} bytes"),
+                ));
             }
 
-            let backoff = 2u64.pow((attempt - 1).min(4));
-            println!(
-                "cargo:warning=Download attempt {}/{} for {} failed ({}). Retrying in {}s...",
-                attempt, max_attempts, name, err_msg, backoff
-            );
-            std::thread::sleep(std::time::Duration::from_secs(backoff));
-        }
+            if file.unix_mode().is_some_and(|mode| mode & 0o170_000 == 0o120_000) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("source archive contains a symbolic link: {}", file.name()),
+                ));
+            }
 
-        let content = content.expect("unreachable: download loop must either succeed or panic");
+            let enclosed_path = file.enclosed_name().ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("source archive contains an unsafe path: {}", file.name()),
+                )
+            })?;
+            let relative_path = enclosed_path.strip_prefix(expected_root).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "source archive entry {} is outside expected root {expected_root}",
+                        enclosed_path.display()
+                    ),
+                )
+            })?;
 
-        eprintln!("Downloaded {} bytes for {}", content.len(), name);
-
-        let temp_file = target_dir.join(format!("{}.zip", name));
-        fs::write(&temp_file, content).expect("Failed to write archive to file");
-
-        let extract_dir = target_dir.join(name);
-        if extract_dir.exists() {
-            fs::remove_dir_all(&extract_dir).expect("Failed to remove existing directory");
-        }
-        fs::create_dir_all(&extract_dir).expect("Failed to create extraction directory");
-
-        let mut archive = ZipArchive::new(fs::File::open(&temp_file).unwrap()).unwrap();
-
-        for i in 0..archive.len() {
-            let mut file = archive.by_index(i).unwrap();
-            let file_path = file.mangled_name();
-            let file_path = file_path.to_str().unwrap();
-
-            let path = Path::new(file_path);
-            let path = path.strip_prefix(path.components().next().unwrap()).unwrap();
-
-            if path.as_os_str().is_empty() {
+            if relative_path.as_os_str().is_empty() {
                 continue;
             }
 
-            let target_path = extract_dir.join(path);
+            let target_path = destination.join(relative_path);
 
             if file.is_dir() {
-                fs::create_dir_all(target_path).unwrap();
+                fs::create_dir_all(target_path)?;
             } else {
                 if let Some(parent) = target_path.parent() {
-                    fs::create_dir_all(parent).unwrap();
+                    fs::create_dir_all(parent)?;
                 }
-                let mut outfile = fs::File::create(target_path).unwrap();
-                std::io::copy(&mut file, &mut outfile).unwrap();
+                let mut output = fs::File::create(target_path)?;
+                std::io::copy(&mut file, &mut output)?;
             }
         }
 
-        fs::remove_file(temp_file).expect("Failed to remove temporary zip file");
+        Ok(())
+    }
 
-        extract_dir
+    fn invalid_archive(error: zip::result::ZipError) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, format!("invalid source archive: {error}"))
     }
 
     /// Download a single file to a destination path with retries.
     /// Download a single file, trying each URL in order. Each URL gets up to
     /// `max_attempts` retries with exponential backoff before falling through
     /// to the next URL.
-    fn download_file_with_fallback(urls: &[&str], dest: &Path, label: &str) {
+    fn download_file_with_fallback(
+        urls: &[&str],
+        destination: &Path,
+        label: &str,
+        expected_size: u64,
+    ) -> io::Result<()> {
         let client = reqwest::blocking::Client::builder()
             .timeout(std::time::Duration::from_secs(300))
             .http1_only()
             .build()
-            .expect("Failed to create HTTP client");
+            .map_err(io::Error::other)?;
 
         let max_attempts: u32 = 5;
         let mut last_err = String::new();
@@ -1043,13 +1115,18 @@ mod build_tesseract {
                 let err_msg = match client.get(*url).send() {
                     Ok(resp) => {
                         if resp.status().is_success() {
-                            match resp.bytes() {
-                                Ok(bytes) => {
-                                    fs::write(dest, &bytes).expect("Failed to write downloaded file");
-                                    eprintln!("Downloaded {} ({} bytes)", label, bytes.len());
-                                    return;
+                            if let Some(content_length) = resp.content_length()
+                                && content_length != expected_size
+                            {
+                                format!("unexpected Content-Length {content_length}, expected {expected_size}")
+                            } else {
+                                match write_bounded_response(resp, destination, expected_size) {
+                                    Ok(()) => {
+                                        eprintln!("Downloaded {label} ({expected_size} bytes)");
+                                        return Ok(());
+                                    }
+                                    Err(error) => error.to_string(),
                                 }
-                                Err(err) => format!("Failed to read response: {}", err),
                             }
                         } else {
                             format!("HTTP {}", resp.status().as_u16())
@@ -1077,12 +1154,30 @@ mod build_tesseract {
             }
         }
 
-        panic!(
-            "Failed to download {} after trying {} URL(s): {}",
-            label,
-            urls.len(),
-            last_err
-        );
+        Err(io::Error::other(format!(
+            "failed to download {label} after trying {} URL(s): {last_err}",
+            urls.len()
+        )))
+    }
+
+    fn write_bounded_response(
+        response: reqwest::blocking::Response,
+        destination: &Path,
+        expected_size: u64,
+    ) -> io::Result<()> {
+        use std::io::Read;
+
+        let mut bounded = response.take(expected_size.saturating_add(1));
+        let mut output = fs::File::create(destination)?;
+        let written = io::copy(&mut bounded, &mut output)?;
+        if written != expected_size {
+            let _ = fs::remove_file(destination);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("downloaded {written} bytes, expected exactly {expected_size}"),
+            ));
+        }
+        Ok(())
     }
 
     fn normalize_cmake_path(path: &Path) -> String {
@@ -1437,13 +1532,6 @@ namespace this_thread {
         }
     }
 
-    fn clean_cache(cache_dir: &Path) {
-        println!("Cleaning cache directory: {:?}", cache_dir);
-        if cache_dir.exists() {
-            fs::remove_dir_all(cache_dir).expect("Failed to remove cache directory");
-        }
-    }
-
     fn build_leptonica_wasm(leptonica_src: &Path, leptonica_install: &Path, wasi_sdk_dir: &Path) {
         let toolchain_file = find_wasi_toolchain(wasi_sdk_dir);
         let sysroot = wasi_sdk_dir.join("share/wasi-sysroot");
@@ -1486,11 +1574,9 @@ namespace this_thread {
     fn build_wasm() {
         eprintln!("Building for WASM target with WASI SDK");
 
-        let custom_out_dir = prepare_out_dir();
-        let cache_dir = custom_out_dir.join("cache");
-        fs::create_dir_all(&cache_dir).expect("Failed to create cache directory");
-
-        let project_dir = custom_out_dir.clone();
+        let artifact_cache_dir = prepare_out_dir().join("source-artifacts");
+        let build_root = cargo_build_root();
+        let project_dir = build_root.clone();
         let third_party_dir = project_dir.join("third_party");
 
         eprintln!("Looking for WASI SDK...");
@@ -1512,38 +1598,41 @@ Installation instructions:
             }
         };
 
-        let leptonica_dir = get_or_download_source(&third_party_dir, &leptonica_url(), "leptonica").path;
+        let leptonica_dir = get_or_download_source(
+            &artifact_cache_dir,
+            &third_party_dir,
+            &LEPTONICA_SOURCE,
+            &leptonica_url(),
+        )
+        .path;
 
-        let tesseract_source = get_or_download_source(&third_party_dir, &tesseract_url(), "tesseract");
-        if tesseract_source.downloaded {
-            apply_tesseract_wasm_patch(&tesseract_source.path);
-            apply_wasm_noop_mutex_patch(&tesseract_source.path);
-        }
+        let tesseract_source = get_or_download_source(
+            &artifact_cache_dir,
+            &third_party_dir,
+            &TESSERACT_SOURCE,
+            &tesseract_url(),
+        );
+        apply_tesseract_wasm_patch(&tesseract_source.path);
+        apply_wasm_noop_mutex_patch(&tesseract_source.path);
         let tesseract_dir = tesseract_source.path;
 
-        let leptonica_install_dir = custom_out_dir.join("leptonica");
-        let leptonica_cache_dir = cache_dir.join("leptonica");
+        let leptonica_install_dir = build_root.join("leptonica");
+        let _leptonica_link_name = build_static_library("leptonica", &leptonica_install_dir, || {
+            eprintln!("Building Leptonica for WASM...");
+            build_leptonica_wasm(&leptonica_dir, &leptonica_install_dir, &wasi_sdk_dir);
+        });
 
-        let _leptonica_link_name =
-            build_or_use_cached("leptonica", &leptonica_cache_dir, &leptonica_install_dir, || {
-                eprintln!("Building Leptonica for WASM...");
-                build_leptonica_wasm(&leptonica_dir, &leptonica_install_dir, &wasi_sdk_dir);
-            });
-
-        let tesseract_install_dir = custom_out_dir.join("tesseract");
-        let tesseract_cache_dir = cache_dir.join("tesseract");
-
-        let _tesseract_link_name =
-            build_or_use_cached("tesseract", &tesseract_cache_dir, &tesseract_install_dir, || {
-                eprintln!("Building Tesseract for WASM (SIMD enabled)...");
-                build_tesseract_wasm(
-                    &tesseract_dir,
-                    &tesseract_install_dir,
-                    &leptonica_install_dir,
-                    &wasi_sdk_dir,
-                    true,
-                );
-            });
+        let tesseract_install_dir = build_root.join("tesseract");
+        let _tesseract_link_name = build_static_library("tesseract", &tesseract_install_dir, || {
+            eprintln!("Building Tesseract for WASM (SIMD enabled)...");
+            build_tesseract_wasm(
+                &tesseract_dir,
+                &tesseract_install_dir,
+                &leptonica_install_dir,
+                &wasi_sdk_dir,
+                true,
+            );
+        });
 
         let leptonica_lib_dir = leptonica_install_dir.join("lib");
         let tesseract_lib_dir = tesseract_install_dir.join("lib");
@@ -1578,16 +1667,7 @@ Installation instructions:
 
         let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
         let eng_traineddata = PathBuf::from(&out_dir).join("eng.traineddata");
-        if !eng_traineddata.exists() {
-            download_file_with_fallback(
-                &[
-                    "https://github.com/tesseract-ocr/tessdata_fast/raw/main/eng.traineddata",
-                    "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/main/eng.traineddata",
-                ],
-                &eng_traineddata,
-                "eng.traineddata",
-            );
-        }
+        prepare_eng_traineddata(&artifact_cache_dir, &eng_traineddata);
 
         eprintln!("WASM build completed successfully!");
         eprintln!("Leptonica install dir: {:?}", leptonica_install_dir);
@@ -1689,7 +1769,7 @@ Installation instructions:
         config.build();
     }
 
-    fn build_or_use_cached<F>(name: &str, cache_dir: &Path, install_dir: &Path, build_fn: F) -> String
+    fn build_static_library<F>(name: &str, install_dir: &Path, build_fn: F) -> String
     where
         F: FnOnce(),
     {
@@ -1705,8 +1785,6 @@ Installation instructions:
             format!("lib{}.a", name)
         };
 
-        let cached_path = cache_dir.join(&lib_name);
-        let marker_path = cache_dir.join(format!("{}.target", name));
         let out_path = install_dir.join("lib").join(&lib_name);
 
         let possible_lib_names: Vec<String> = if is_windows {
@@ -1762,7 +1840,10 @@ Installation instructions:
             vec![format!("lib{}.a", name)]
         };
 
-        fs::create_dir_all(cache_dir).expect("Failed to create cache directory");
+        if install_dir.exists() {
+            fs::remove_dir_all(install_dir)
+                .unwrap_or_else(|error| panic!("Failed to remove stale {name} install directory: {error}"));
+        }
         fs::create_dir_all(out_path.parent().unwrap()).expect("Failed to create output directory");
 
         let candidate_lib_dirs = [
@@ -1771,42 +1852,7 @@ Installation instructions:
             install_dir.join("lib").join("tesseract"),
         ];
 
-        let cache_valid = cached_path.exists()
-            && {
-                match fs::read_to_string(&marker_path) {
-                    Ok(cached_target) => {
-                        let valid = cached_target.trim() == target_triple;
-                        if !valid {
-                            println!(
-                                "cargo:warning=Cached {} library is for wrong architecture (cached: {}, current: {}), rebuilding",
-                                name,
-                                cached_target.trim(),
-                                target_triple
-                            );
-                            let _ = fs::remove_file(&cached_path);
-                            let _ = fs::remove_file(&marker_path);
-                        }
-                        valid
-                    }
-                    Err(_) => {
-                        println!(
-                            "cargo:warning=Cached {} library missing target marker, rebuilding",
-                            name
-                        );
-                        let _ = fs::remove_file(&cached_path);
-                        false
-                    }
-                }
-            };
-
-        let link_name_to_use = if cache_valid {
-            eprintln!("Using cached {} library for {}", name, target_triple);
-            if let Err(e) = fs::copy(&cached_path, &out_path) {
-                eprintln!("Failed to copy cached library: {}", e);
-                build_fn();
-            }
-            name.to_string()
-        } else {
+        let link_name_to_use = {
             println!("Building {} library", name);
             build_fn();
 
@@ -1841,13 +1887,6 @@ Installation instructions:
                     );
                 } else if let Err(e) = fs::copy(&lib_path, &out_path) {
                     eprintln!("Failed to copy library to standard location: {}", e);
-                }
-                if let Err(e) = fs::copy(&lib_path, &cached_path) {
-                    eprintln!("Failed to cache library: {}", e);
-                } else if let Err(e) = fs::write(&marker_path, &target_triple) {
-                    eprintln!("Failed to write cache marker: {}", e);
-                } else {
-                    eprintln!("Cached {} library for {}", name, target_triple);
                 }
                 link_name
             } else {

--- a/crates/xberg-tesseract/build_support/source_cache.rs
+++ b/crates/xberg-tesseract/build_support/source_cache.rs
@@ -1,8 +1,27 @@
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
 const SOURCE_ROOT_MARKER: &str = "CMakeLists.txt";
+const SHA256_HEX_LENGTH: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SourceArtifact<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) cache_key: &'a str,
+    pub(crate) sha256: &'a str,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct VerifiedArtifact {
+    pub(crate) path: PathBuf,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) downloaded: bool,
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct PreparedSourceTree {
@@ -14,50 +33,274 @@ pub(crate) fn source_tree_is_complete(source_dir: &Path) -> bool {
     source_dir.is_dir() && source_dir.join(SOURCE_ROOT_MARKER).is_file()
 }
 
-pub(crate) fn prepare_source_tree(
-    third_party_dir: &Path,
-    source_name: &str,
-    download: impl FnOnce(&Path),
-) -> io::Result<PreparedSourceTree> {
-    fs::create_dir_all(third_party_dir)?;
+pub(crate) fn prepare_verified_artifact(
+    cache_root: &Path,
+    artifact: &SourceArtifact<'_>,
+    fetch: impl FnOnce(&Path) -> io::Result<()>,
+) -> io::Result<VerifiedArtifact> {
+    validate_artifact(artifact)?;
+    ensure_directory(cache_root)?;
 
-    let source_dir = third_party_dir.join(source_name);
-    if source_tree_is_complete(&source_dir) {
-        return Ok(PreparedSourceTree {
-            path: source_dir,
+    let cache_key_dir = cache_root.join(artifact.cache_key);
+    ensure_directory(&cache_key_dir)?;
+    let digest_dir = cache_key_dir.join(artifact.sha256);
+    ensure_directory(&digest_dir)?;
+    let artifact_path = digest_dir.join(artifact.name);
+    if artifact_path.exists() {
+        let bytes = read_verified_file(&artifact_path, artifact)?;
+        return Ok(VerifiedArtifact {
+            path: artifact_path,
+            bytes,
             downloaded: false,
         });
     }
 
-    remove_incomplete_source(&source_dir)?;
-    download(third_party_dir);
-
-    if !source_tree_is_complete(&source_dir) {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "downloaded {source_name} source is incomplete: missing {}",
-                source_dir.join(SOURCE_ROOT_MARKER).display()
-            ),
-        ));
+    let temporary_path = temporary_path(&artifact_path);
+    remove_if_exists(&temporary_path)?;
+    if let Err(error) = fetch(&temporary_path) {
+        let _ = remove_if_exists(&temporary_path);
+        return Err(error);
     }
 
-    Ok(PreparedSourceTree {
-        path: source_dir,
+    let bytes = match read_verified_file(&temporary_path, artifact) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            let _ = remove_if_exists(&temporary_path);
+            return Err(error);
+        }
+    };
+
+    match fs::rename(&temporary_path, &artifact_path) {
+        Ok(()) => {}
+        Err(_) if artifact_path.exists() => {
+            remove_if_exists(&temporary_path)?;
+            let bytes = read_verified_file(&artifact_path, artifact)?;
+            return Ok(VerifiedArtifact {
+                path: artifact_path,
+                bytes,
+                downloaded: false,
+            });
+        }
+        Err(error) => {
+            let _ = remove_if_exists(&temporary_path);
+            return Err(error);
+        }
+    }
+
+    Ok(VerifiedArtifact {
+        path: artifact_path,
+        bytes,
         downloaded: true,
     })
 }
 
-fn remove_incomplete_source(source_dir: &Path) -> io::Result<()> {
-    let metadata = match fs::symlink_metadata(source_dir) {
+pub(crate) fn prepare_source_tree(
+    third_party_dir: &Path,
+    source_name: &str,
+    archive: &VerifiedArtifact,
+    extract: impl FnOnce(&[u8], &Path) -> io::Result<()>,
+) -> io::Result<PreparedSourceTree> {
+    validate_path_component(source_name, "source name")?;
+    ensure_directory(third_party_dir)?;
+
+    let source_dir = third_party_dir.join(source_name);
+    let staging_dir = temporary_path(&source_dir);
+    remove_if_exists(&staging_dir)?;
+    if let Err(error) = extract(&archive.bytes, &staging_dir) {
+        let _ = remove_if_exists(&staging_dir);
+        return Err(error);
+    }
+
+    if !source_tree_is_complete(&staging_dir) {
+        let _ = remove_if_exists(&staging_dir);
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "extracted {source_name} source is incomplete: missing {}",
+                staging_dir.join(SOURCE_ROOT_MARKER).display()
+            ),
+        ));
+    }
+
+    remove_if_exists(&source_dir)?;
+    if let Err(error) = fs::rename(&staging_dir, &source_dir) {
+        let _ = remove_if_exists(&staging_dir);
+        return Err(error);
+    }
+
+    Ok(PreparedSourceTree {
+        path: source_dir,
+        downloaded: archive.downloaded,
+    })
+}
+
+pub(crate) fn copy_verified_artifact(artifact: &VerifiedArtifact, destination: &Path) -> io::Result<()> {
+    let expected = sha256_hex(&artifact.bytes);
+    if destination.exists() {
+        return verify_bytes(&fs::read(destination)?, &expected, &destination.display().to_string());
+    }
+
+    let parent = destination.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("artifact destination has no parent: {}", destination.display()),
+        )
+    })?;
+    ensure_directory(parent)?;
+
+    let temporary_path = temporary_path(destination);
+    remove_if_exists(&temporary_path)?;
+    fs::write(&temporary_path, &artifact.bytes)?;
+
+    if let Err(error) = verify_bytes(
+        &fs::read(&temporary_path)?,
+        &expected,
+        &temporary_path.display().to_string(),
+    ) {
+        let _ = remove_if_exists(&temporary_path);
+        return Err(error);
+    }
+
+    match fs::rename(&temporary_path, destination) {
+        Ok(()) => Ok(()),
+        Err(_) if destination.exists() => {
+            remove_if_exists(&temporary_path)?;
+            verify_bytes(&fs::read(destination)?, &expected, &destination.display().to_string())
+        }
+        Err(error) => {
+            let _ = remove_if_exists(&temporary_path);
+            Err(error)
+        }
+    }
+}
+
+fn read_verified_file(path: &Path, artifact: &SourceArtifact<'_>) -> io::Result<Vec<u8>> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("cached artifact is not a regular file: {}", path.display()),
+        ));
+    }
+
+    let bytes = fs::read(path)?;
+    verify_bytes(&bytes, artifact.sha256, artifact.name)?;
+    Ok(bytes)
+}
+
+fn verify_bytes(bytes: &[u8], expected_sha256: &str, label: &str) -> io::Result<()> {
+    let actual_sha256 = sha256_hex(bytes);
+    if actual_sha256 == expected_sha256 {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("SHA-256 mismatch for {label}: expected {expected_sha256}, got {actual_sha256}"),
+    ))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(SHA256_HEX_LENGTH);
+    for byte in digest {
+        encoded.push(HEX[usize::from(byte >> 4)] as char);
+        encoded.push(HEX[usize::from(byte & 0x0f)] as char);
+    }
+    encoded
+}
+
+fn validate_artifact(artifact: &SourceArtifact<'_>) -> io::Result<()> {
+    validate_path_component(artifact.name, "artifact name")?;
+    validate_path_component(artifact.cache_key, "artifact cache key")?;
+
+    if artifact.sha256.len() != SHA256_HEX_LENGTH
+        || !artifact
+            .sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid SHA-256 digest for {}", artifact.name),
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_path_component(value: &str, label: &str) -> io::Result<()> {
+    let valid = !value.is_empty()
+        && value != "."
+        && value != ".."
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'));
+    if valid {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("invalid {label}: {value}"),
+    ))
+}
+
+fn temporary_path(destination: &Path) -> PathBuf {
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact");
+    destination.with_file_name(format!(".{file_name}.{}.partial", std::process::id()))
+}
+
+pub(crate) fn ensure_directory(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty() && *parent != path)
+    {
+        ensure_directory(parent)?;
+    }
+
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() => Ok(()),
+        Ok(metadata) if trusted_directory_symlink(path, &metadata) => Ok(()),
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("cache path is not a regular directory: {}", path.display()),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => match fs::create_dir(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => ensure_directory(path),
+            Err(error) => Err(error),
+        },
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn trusted_directory_symlink(path: &Path, metadata: &fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
+        && metadata.uid() == 0
+        && fs::metadata(path).is_ok_and(|target| target.file_type().is_dir())
+}
+
+#[cfg(not(unix))]
+fn trusted_directory_symlink(_path: &Path, _metadata: &fs::Metadata) -> bool {
+    false
+}
+
+fn remove_if_exists(path: &Path) -> io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
     };
 
     if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
-        fs::remove_dir_all(source_dir)
+        fs::remove_dir_all(path)
     } else {
-        fs::remove_file(source_dir)
+        fs::remove_file(path)
     }
 }

--- a/crates/xberg-tesseract/licenses/leptonica-LICENSE
+++ b/crates/xberg-tesseract/licenses/leptonica-LICENSE
@@ -1,0 +1,26 @@
+/*====================================================================*
+ -  Copyright (C) 2001-2020 Leptonica.  All rights reserved.
+ -
+ -  Redistribution and use in source and binary forms, with or without
+ -  modification, are permitted provided that the following conditions
+ -  are met:
+ -  1. Redistributions of source code must retain the above copyright
+ -     notice, this list of conditions and the following disclaimer.
+ -  2. Redistributions in binary form must reproduce the above
+ -     copyright notice, this list of conditions and the following
+ -     disclaimer in the documentation and/or other materials
+ -     provided with the distribution.
+ -
+ -  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ -  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ -  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ -  A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL ANY
+ -  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ -  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ -  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ -  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ -  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ -  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ -  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *====================================================================*/
+

--- a/crates/xberg-tesseract/licenses/tesseract-LICENSE
+++ b/crates/xberg-tesseract/licenses/tesseract-LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/xberg-tesseract/tests/source_cache_test.rs
+++ b/crates/xberg-tesseract/tests/source_cache_test.rs
@@ -1,98 +1,345 @@
 #[path = "../build_support/source_cache.rs"]
 mod source_cache;
 
-use source_cache::{prepare_source_tree, source_tree_is_complete};
+use source_cache::{SourceArtifact, copy_verified_artifact, prepare_source_tree, prepare_verified_artifact};
+use std::cell::Cell;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const SOURCE_NAME: &str = "leptonica";
+const ARCHIVE_BYTES: &[u8] = b"verified archive bytes";
+const ARCHIVE_SHA256: &str = "74e79ddd5e5b690dbfb0995c1af7c4a86feaeff0b5f5b8d667fc2cda3360a489";
+const ALTERED_ARCHIVE_BYTES: &[u8] = b"altered archive bytes";
+const MODEL_BYTES: &[u8] = b"verified model bytes";
+const MODEL_SHA256: &str = "03cfa25d83f5eaa1faac98ed6ceaaf0e7afe3c273a1e1502c2714ebe10b8263e";
+const ALTERED_MODEL_BYTES: &[u8] = b"altered model bytes";
+const BUILD_SCRIPT: &str = include_str!("../build.rs");
+
+const PINNED_BUILD_INPUTS: &[&str] = &[
+    "13275a278eb55b5746e33f95fbf5a2c8f604b3ab",
+    "0febcd4fc5cdc9c52d59509b45483d107f9f40922899e3f134ea615094ecbc77",
+    "db0ec62f81b0737fbbe184d8fea40af5738f8eef",
+    "d2470cc33ee34deeae6fc47809d0b33a3623a4343d92ff317ac3b9903c507bad",
+    "87416418657359cb625c412a48b6e1d6d41c29bd",
+    "7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2",
+];
 
 #[test]
-fn should_download_when_source_tree_is_missing() {
+fn should_store_verified_download_in_digest_addressed_cache() {
     let temp_dir = TestDir::new();
-    let third_party_dir = temp_dir.path().join("third_party");
+    let artifact = source_artifact();
 
-    let prepared = prepare_source_tree(&third_party_dir, SOURCE_NAME, |download_dir| {
-        create_complete_source(download_dir, SOURCE_NAME);
+    let prepared = prepare_verified_artifact(temp_dir.path(), &artifact, |download_path| {
+        fs::write(download_path, ARCHIVE_BYTES)
     })
-    .expect("prepare missing source tree");
+    .expect("prepare verified archive");
 
-    assert!(prepared.downloaded, "missing source should be downloaded");
-    assert_eq!(prepared.path, third_party_dir.join(SOURCE_NAME));
-    assert!(source_tree_is_complete(&prepared.path));
+    assert_eq!(
+        prepared.path,
+        temp_dir
+            .path()
+            .join("native-sources")
+            .join(ARCHIVE_SHA256)
+            .join("tesseract.zip")
+    );
+    assert_eq!(prepared.bytes, ARCHIVE_BYTES);
+    assert_eq!(fs::read(&prepared.path).expect("read cached archive"), ARCHIVE_BYTES);
+    assert!(prepared.downloaded, "new archive should be reported as downloaded");
 }
 
 #[test]
-fn should_replace_empty_source_tree() {
+fn should_wire_every_pinned_build_input_through_verification() {
+    validate_build_source_contract(BUILD_SCRIPT).expect("build source contract must hold");
+}
+
+#[test]
+fn should_reject_build_contract_when_digest_is_removed() {
+    let mutated = BUILD_SCRIPT.replace(PINNED_BUILD_INPUTS[1], "");
+
+    let error = validate_build_source_contract(&mutated).expect_err("missing digest must break build contract");
+
+    assert_eq!(error, "missing pinned build input");
+}
+
+#[test]
+fn should_reject_build_contract_when_model_uses_mutable_branch() {
+    let mutated = BUILD_SCRIPT.replace(PINNED_BUILD_INPUTS[4], "main");
+
+    let error = validate_build_source_contract(&mutated).expect_err("mutable model branch must break build contract");
+
+    assert_eq!(error, "missing pinned build input");
+}
+
+#[test]
+fn should_reuse_verified_content_addressed_cache_entry_without_fetching() {
     let temp_dir = TestDir::new();
-    let third_party_dir = temp_dir.path().join("third_party");
-    let source_dir = third_party_dir.join(SOURCE_NAME);
-    let sibling_dir = third_party_dir.join("tesseract");
-    fs::create_dir_all(&source_dir).expect("create empty source tree");
-    fs::create_dir_all(&sibling_dir).expect("create sibling source tree");
-    fs::write(sibling_dir.join("keep.txt"), "preserve sibling").expect("write sibling sentinel");
-
-    let prepared = prepare_source_tree(&third_party_dir, SOURCE_NAME, |download_dir| {
-        assert!(!source_dir.exists(), "empty source should be removed before download");
-        create_complete_source(download_dir, SOURCE_NAME);
+    let artifact = source_artifact();
+    prepare_verified_artifact(temp_dir.path(), &artifact, |download_path| {
+        fs::write(download_path, ARCHIVE_BYTES)
     })
-    .expect("replace empty source tree");
+    .expect("seed verified archive");
+    let fetch_called = Cell::new(false);
 
-    assert!(prepared.downloaded, "empty source should be downloaded again");
+    let prepared = prepare_verified_artifact(temp_dir.path(), &artifact, |_| {
+        fetch_called.set(true);
+        Ok(())
+    })
+    .expect("reuse verified archive");
+
+    assert!(!fetch_called.get(), "verified cache reuse must not fetch");
     assert!(
-        sibling_dir.join("keep.txt").is_file(),
-        "sibling cache must be preserved"
+        !prepared.downloaded,
+        "reused archive must not be reported as downloaded"
+    );
+    assert_eq!(prepared.bytes, ARCHIVE_BYTES);
+}
+
+#[test]
+fn should_reject_download_when_archive_bytes_do_not_match_digest() {
+    let temp_dir = TestDir::new();
+    let artifact = source_artifact();
+
+    let error = prepare_verified_artifact(temp_dir.path(), &artifact, |download_path| {
+        fs::write(download_path, ALTERED_ARCHIVE_BYTES)
+    })
+    .expect_err("altered archive must be rejected");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(!expected_cache_path(temp_dir.path()).exists());
+}
+
+#[test]
+fn should_reject_artifact_when_digest_is_missing_before_fetching() {
+    let temp_dir = TestDir::new();
+    let artifact = SourceArtifact {
+        name: "tesseract.zip",
+        cache_key: "native-sources",
+        sha256: "",
+    };
+    let fetch_called = Cell::new(false);
+
+    let error = prepare_verified_artifact(temp_dir.path(), &artifact, |_| {
+        fetch_called.set(true);
+        Ok(())
+    })
+    .expect_err("missing digest must be rejected");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    assert!(!fetch_called.get(), "missing digest must fail before fetch");
+}
+
+#[test]
+fn should_reject_corrupt_cache_entry_without_fetching() {
+    let temp_dir = TestDir::new();
+    let artifact = source_artifact();
+    let prepared = prepare_verified_artifact(temp_dir.path(), &artifact, |download_path| {
+        fs::write(download_path, ARCHIVE_BYTES)
+    })
+    .expect("seed verified archive");
+    fs::write(&prepared.path, ALTERED_ARCHIVE_BYTES).expect("corrupt cached archive");
+    let fetch_called = Cell::new(false);
+
+    let error = prepare_verified_artifact(temp_dir.path(), &artifact, |_| {
+        fetch_called.set(true);
+        Ok(())
+    })
+    .expect_err("corrupt cache entry must fail closed");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(!fetch_called.get(), "corrupt cache must not trigger replacement fetch");
+}
+
+#[cfg(unix)]
+#[test]
+fn should_reject_symlinked_cache_component() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TestDir::new();
+    let outside_dir = temp_dir.path().join("outside");
+    fs::create_dir(&outside_dir).expect("create outside directory");
+    symlink(&outside_dir, temp_dir.path().join("native-sources")).expect("create cache symlink");
+    let fetch_called = Cell::new(false);
+
+    let error = prepare_verified_artifact(temp_dir.path(), &source_artifact(), |_| {
+        fetch_called.set(true);
+        Ok(())
+    })
+    .expect_err("symlinked cache component must fail closed");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(!fetch_called.get(), "symlink rejection must precede fetch");
+    assert_eq!(fs::read_dir(&outside_dir).expect("read outside directory").count(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn should_reject_cache_path_beneath_symlinked_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TestDir::new();
+    let outside_dir = temp_dir.path().join("outside-root");
+    fs::create_dir(&outside_dir).expect("create outside directory");
+    let outside_artifacts = outside_dir.join("source-artifacts");
+    fs::create_dir(&outside_artifacts).expect("create pre-existing outside artifact directory");
+    let cache_root = temp_dir.path().join("cache-root");
+    symlink(&outside_dir, &cache_root).expect("create cache-root symlink");
+    let fetch_called = Cell::new(false);
+
+    let error = prepare_verified_artifact(&cache_root.join("source-artifacts"), &source_artifact(), |_| {
+        fetch_called.set(true);
+        Ok(())
+    })
+    .expect_err("cache path beneath a symlinked root must fail closed");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(!fetch_called.get(), "symlink rejection must precede fetch");
+    assert_eq!(
+        fs::read_dir(&outside_artifacts)
+            .expect("read outside directory")
+            .count(),
+        0
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn should_reject_symlinked_source_root_without_removing_target() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TestDir::new();
+    let archive = prepare_verified_artifact(temp_dir.path(), &source_artifact(), |download_path| {
+        fs::write(download_path, ARCHIVE_BYTES)
+    })
+    .expect("prepare verified archive");
+    let outside_dir = temp_dir.path().join("outside-source");
+    fs::create_dir(&outside_dir).expect("create outside source directory");
+    fs::write(outside_dir.join("sentinel"), "preserve").expect("write outside sentinel");
+    let third_party_dir = temp_dir.path().join("third-party");
+    symlink(&outside_dir, &third_party_dir).expect("create source-root symlink");
+
+    let error = prepare_source_tree(&third_party_dir, "tesseract", &archive, |_, _| Ok(()))
+        .expect_err("symlinked source root must fail closed");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        outside_dir.join("sentinel").is_file(),
+        "outside target must remain intact"
     );
 }
 
 #[test]
-fn should_replace_incomplete_source_tree() {
+fn should_replace_poisoned_complete_source_tree_before_extraction() {
     let temp_dir = TestDir::new();
-    let third_party_dir = temp_dir.path().join("third_party");
-    let source_dir = third_party_dir.join(SOURCE_NAME);
-    fs::create_dir_all(&source_dir).expect("create incomplete source tree");
-    fs::write(source_dir.join("README.md"), "partial archive").expect("write partial source file");
-
-    let prepared = prepare_source_tree(&third_party_dir, SOURCE_NAME, |download_dir| {
-        assert!(
-            !source_dir.exists(),
-            "incomplete source should be removed before download"
-        );
-        create_complete_source(download_dir, SOURCE_NAME);
+    let artifact = prepare_verified_artifact(temp_dir.path(), &source_artifact(), |download_path| {
+        fs::write(download_path, ARCHIVE_BYTES)
     })
-    .expect("replace incomplete source tree");
+    .expect("prepare verified archive");
+    let third_party_dir = temp_dir.path().join("third-party");
+    let source_dir = third_party_dir.join("tesseract");
+    fs::create_dir_all(&source_dir).expect("create poisoned source tree");
+    fs::write(source_dir.join("CMakeLists.txt"), "poisoned build").expect("write poisoned marker");
+    fs::write(source_dir.join("poisoned.cpp"), "malicious source").expect("write poisoned source");
+    let extraction_called = Cell::new(false);
 
-    assert!(prepared.downloaded, "incomplete source should be downloaded again");
+    let prepared = prepare_source_tree(&third_party_dir, "tesseract", &artifact, |bytes, destination| {
+        extraction_called.set(true);
+        assert_eq!(bytes, ARCHIVE_BYTES);
+        assert!(!destination.exists(), "poisoned tree must be removed before extraction");
+        fs::create_dir_all(destination)?;
+        fs::write(destination.join("CMakeLists.txt"), "verified build")?;
+        Ok(())
+    })
+    .expect("reconstruct source tree from verified archive");
+
     assert!(
-        !prepared.path.join("README.md").exists(),
-        "partial source contents must be removed"
+        extraction_called.get(),
+        "complete-looking source tree must not be reused"
+    );
+    assert_eq!(
+        fs::read_to_string(prepared.path.join("CMakeLists.txt")).expect("read verified marker"),
+        "verified build"
+    );
+    assert!(!prepared.path.join("poisoned.cpp").exists());
+}
+
+#[test]
+fn should_fail_before_source_preparation_when_archive_is_altered() {
+    let temp_dir = TestDir::new();
+    let artifact = source_artifact();
+    let extraction_called = Cell::new(false);
+
+    let error = prepare_verified_artifact(temp_dir.path(), &artifact, |download_path| {
+        fs::write(download_path, ALTERED_ARCHIVE_BYTES)
+    })
+    .and_then(|verified| {
+        prepare_source_tree(&temp_dir.path().join("third-party"), "tesseract", &verified, |_, _| {
+            extraction_called.set(true);
+            Ok(())
+        })
+    })
+    .expect_err("altered archive must fail verification");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        !extraction_called.get(),
+        "verification failure must precede source preparation"
     );
 }
 
 #[test]
-fn should_reuse_complete_source_tree() {
+fn should_reject_altered_existing_model_file() {
     let temp_dir = TestDir::new();
-    let third_party_dir = temp_dir.path().join("third_party");
-    create_complete_source(&third_party_dir, SOURCE_NAME);
-    let sentinel = third_party_dir.join(SOURCE_NAME).join("README.md");
-    fs::write(&sentinel, "cached source").expect("write cached source sentinel");
-    let mut download_called = false;
-
-    let prepared = prepare_source_tree(&third_party_dir, SOURCE_NAME, |_| {
-        download_called = true;
+    let model = SourceArtifact {
+        name: "eng.traineddata",
+        cache_key: "tessdata",
+        sha256: MODEL_SHA256,
+    };
+    let verified = prepare_verified_artifact(temp_dir.path(), &model, |download_path| {
+        fs::write(download_path, MODEL_BYTES)
     })
-    .expect("reuse complete source tree");
+    .expect("prepare verified model");
+    let destination = temp_dir.path().join("out").join("eng.traineddata");
+    fs::create_dir_all(destination.parent().expect("model parent")).expect("create model output directory");
+    fs::write(&destination, ALTERED_MODEL_BYTES).expect("write altered installed model");
 
-    assert!(!prepared.downloaded, "complete source should be reused");
-    assert!(!download_called, "download must not run for a complete source");
-    assert!(sentinel.is_file(), "reused source contents must be preserved");
+    let error = copy_verified_artifact(&verified, &destination).expect_err("altered model must fail closed");
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(fs::read(&destination).expect("read altered model"), ALTERED_MODEL_BYTES);
 }
 
-fn create_complete_source(third_party_dir: &Path, source_name: &str) {
-    let source_dir = third_party_dir.join(source_name);
-    fs::create_dir_all(&source_dir).expect("create complete source tree");
-    fs::write(source_dir.join("CMakeLists.txt"), "cmake_minimum_required(VERSION 3.5)").expect("write source marker");
+fn source_artifact() -> SourceArtifact<'static> {
+    SourceArtifact {
+        name: "tesseract.zip",
+        cache_key: "native-sources",
+        sha256: ARCHIVE_SHA256,
+    }
+}
+
+fn expected_cache_path(root: &Path) -> PathBuf {
+    root.join("native-sources").join(ARCHIVE_SHA256).join("tesseract.zip")
+}
+
+fn validate_build_source_contract(build_script: &str) -> Result<(), &'static str> {
+    if PINNED_BUILD_INPUTS.iter().any(|input| !build_script.contains(input)) {
+        return Err("missing pinned build input");
+    }
+    if build_script.contains("refs/tags") || build_script.contains("tessdata_fast/main") {
+        return Err("mutable build input URL");
+    }
+    if build_script.matches("&LEPTONICA_SOURCE").count() != 2
+        || build_script.matches("&TESSERACT_SOURCE").count() != 2
+        || build_script
+            .matches("prepare_eng_traineddata(&artifact_cache_dir")
+            .count()
+            != 2
+        || !build_script.contains("prepare_verified_artifact(artifact_cache_dir, &source.artifact")
+        || !build_script.contains("prepare_verified_artifact(artifact_cache_dir, &ENG_TRAINEDDATA_ARTIFACT")
+    {
+        return Err("build input bypasses verification");
+    }
+    Ok(())
 }
 
 struct TestDir {


### PR DESCRIPTION
Pins Tesseract, Leptonica, and English tessdata to immutable revisions with verified digests, bounded extraction, fail-closed caches, and exact redistribution licenses. Mutable build trees are isolated per Cargo build unit. Fixes #1514; tracks xberg-io/xberg-enterprise#970.