### PR TITLE
fix(build): include cstddef in libwpd table header

### DIFF
--- a/crates/xberg-libwpd/build.rs
+++ b/crates/xberg-libwpd/build.rs
@@ -27,8 +27,13 @@
 mod build_target_flags;
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[path = "build_wpd_patches.rs"]
+mod build_wpd_patches;
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod build_libwpd {
     use super::build_target_flags::msvc_only_flags;
+    use super::build_wpd_patches::patch_wpx_table_header;
     use flate2::read::GzDecoder;
     use sha2::{Digest, Sha256};
     use std::env;
@@ -229,6 +234,14 @@ mod build_libwpd {
         fs::write(&path, patched).unwrap_or_else(|e| panic!("writing {path:?}: {e}"));
     }
 
+    fn patch_wpd_table_header(wpd: &Path) {
+        let path = wpd.join("src/lib/WPXTable.h");
+        let source = fs::read_to_string(&path).unwrap_or_else(|error| panic!("reading {path:?}: {error}"));
+        let patched = patch_wpx_table_header(&source)
+            .unwrap_or_else(|error| panic!("patching direct cstddef include in {path:?}: {error}"));
+        fs::write(&path, patched).unwrap_or_else(|error| panic!("writing {path:?}: {error}"));
+    }
+
     pub fn build() {
         let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is set by cargo"));
 
@@ -244,6 +257,7 @@ mod build_libwpd {
             Some(LIBWPD_SHA256),
             &format!("libwpd-{LIBWPD_VERSION}"),
         );
+        patch_wpd_table_header(&wpd);
         patch_wpd_msvc_narrowing(&wpd);
         // Extracting `boost-subset.tar.gz` reproduces the `boost/boost/...`
         // layout `bcp` produces, so the include root is the extracted `boost`

--- a/crates/xberg-libwpd/build_wpd_patches.rs
+++ b/crates/xberg-libwpd/build_wpd_patches.rs
@@ -1,0 +1,13 @@
+pub fn patch_wpx_table_header(source: &str) -> Result<String, &'static str> {
+    const CSTDDEF_INCLUDE: &str = "#include <cstddef>";
+    const VECTOR_INCLUDE: &str = "#include <vector>";
+
+    if source.contains(CSTDDEF_INCLUDE) {
+        return Ok(source.to_string());
+    }
+    if !source.contains(VECTOR_INCLUDE) {
+        return Err("WPXTable.h is missing its vector include anchor");
+    }
+
+    Ok(source.replacen(VECTOR_INCLUDE, "#include <cstddef>\n#include <vector>", 1))
+}

--- a/crates/xberg-libwpd/tests/build_wpd_patches.rs
+++ b/crates/xberg-libwpd/tests/build_wpd_patches.rs
@@ -1,0 +1,33 @@
+#[path = "../build_wpd_patches.rs"]
+mod build_wpd_patches;
+
+use build_wpd_patches::patch_wpx_table_header;
+
+#[test]
+fn should_add_cstddef_before_vector_include() {
+    let source = "#ifndef _WPXTABLE_H\n#define _WPXTABLE_H\n\n#include <vector>\n";
+
+    let patched = patch_wpx_table_header(source).expect("patch WPXTable header");
+
+    assert_eq!(
+        patched,
+        "#ifndef _WPXTABLE_H\n#define _WPXTABLE_H\n\n#include <cstddef>\n#include <vector>\n"
+    );
+}
+
+#[test]
+fn should_leave_patched_header_unchanged() {
+    let source = "#include <cstddef>\n#include <vector>\n";
+
+    assert_eq!(
+        patch_wpx_table_header(source).expect("accept patched WPXTable header"),
+        source
+    );
+}
+
+#[test]
+fn should_reject_header_without_vector_anchor() {
+    let error = patch_wpx_table_header("#include <string>\n").expect_err("missing anchor must fail closed");
+
+    assert_eq!(error, "WPXTable.h is missing its vector include anchor");
+}


### PR DESCRIPTION
Patch the checksum-verified libwpd source after extraction so WPXTable.h directly includes <cstddef> before native compilation. This restores GCC 12+ builds without changing the pinned vendor archive. Fixes #1518; tracks xberg-io/xberg-enterprise#972.