### PR TITLE
fix(security): force offline JSON Schema resolution

### DIFF
--- a/crates/xberg/Cargo.toml
+++ b/crates/xberg/Cargo.toml
@@ -1660,9 +1660,8 @@ criterion = { workspace = true }
 dotenvy = "0.15"
 filetime = "0.2"
 image = { workspace = true, default-features = false, features = ["png"] }
-# default-features=false drops jsonschema's `resolve-http` (reqwest→native-tls→openssl-sys);
-# tests validate local schemas only. Keeps the test build openssl-free.
-jsonschema = { version = "0.52", default-features = false }
+# Test retrieval features prove runtime compilation stays offline under Cargo feature unification. ~keep
+jsonschema = { version = "0.52", default-features = false, features = ["resolve-file", "resolve-http", "tls-ring"] }
 qrcode = { version = "0.14", default-features = false, features = ["image"] }
 # Test-only: builds an in-memory model2vec fixture (safetensors bytes) for the
 # static_engine unit tests, without a network fetch.

--- a/crates/xberg/src/engine/structured/schema.rs
+++ b/crates/xberg/src/engine/structured/schema.rs
@@ -69,7 +69,7 @@ pub fn validate_and_merge(
         };
     }
 
-    let validator = match jsonschema::validator_for(schema) {
+    let validator = match jsonschema::draft202012::options().offline().build(schema) {
         Ok(v) => v,
         Err(e) => {
             return MergedOutput {
@@ -173,7 +173,57 @@ fn merge_validated(batches: Vec<serde_json::Value>, merge_mode: MergeMode) -> se
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
     use super::*;
+
+    const SCHEMA_SERVER_TIMEOUT: Duration = Duration::from_secs(2);
+    const SCHEMA_SERVER_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+    fn serve_schema_once() -> (String, std::net::SocketAddr, thread::JoinHandle<bool>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback schema server");
+        listener.set_nonblocking(true).expect("make schema server nonblocking");
+        let address = listener.local_addr().expect("read schema server address");
+        let handle = thread::spawn(move || {
+            let deadline = Instant::now() + SCHEMA_SERVER_TIMEOUT;
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_read_timeout(Some(SCHEMA_SERVER_TIMEOUT))
+                            .expect("set schema request timeout");
+                        let mut request_prefix = [0_u8; b"TEST SHUTDOWN".len()];
+                        stream
+                            .read_exact(&mut request_prefix)
+                            .expect("read schema request prefix");
+                        if request_prefix == *b"TEST SHUTDOWN" {
+                            return false;
+                        }
+
+                        let body = r#"{"type":"object"}"#;
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .expect("write schema response");
+                        return true;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return false;
+                        }
+                        thread::sleep(SCHEMA_SERVER_POLL_INTERVAL);
+                    }
+                    Err(error) => panic!("accept schema request: {error}"),
+                }
+            }
+        });
+        (format!("http://{address}/schema.json"), address, handle)
+    }
 
     #[test]
     fn object_merge_happy_path() {
@@ -301,5 +351,72 @@ mod tests {
 
         assert_eq!(result.outcome, Outcome::Success);
         assert_eq!(result.merged.get("key").map(|v| v.as_str()), Some(Some("value")));
+    }
+
+    #[test]
+    fn should_reject_remote_schema_references_without_http_access() {
+        let (schema_url, address, server) = serve_schema_once();
+        let schema = serde_json::json!({"$ref": schema_url});
+        let result = validate_and_merge(vec![serde_json::json!({})], &schema, MergeMode::ObjectMerge);
+        if let Ok(mut shutdown) = TcpStream::connect(address) {
+            shutdown.write_all(b"TEST SHUTDOWN").expect("stop schema server");
+        }
+        let was_accessed = server.join().expect("join schema server");
+
+        assert!(!was_accessed, "schema compilation must not access remote HTTP targets");
+        assert_eq!(result.outcome, Outcome::Error);
+        assert!(
+            result
+                .error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("Retrieval is disabled")),
+            "offline rejection must explain that retrieval is disabled: {:?}",
+            result.error_message
+        );
+    }
+
+    #[test]
+    fn should_reject_file_schema_references_when_the_target_exists() {
+        let mut target = tempfile::NamedTempFile::new().expect("create referenced schema file");
+        target
+            .write_all(br#"{"type":"object"}"#)
+            .expect("write referenced schema");
+        let schema_url = url::Url::from_file_path(target.path())
+            .expect("convert referenced schema path to file URL")
+            .to_string();
+        let schema = serde_json::json!({"$ref": schema_url});
+
+        let result = validate_and_merge(vec![serde_json::json!({})], &schema, MergeMode::ObjectMerge);
+
+        assert_eq!(result.outcome, Outcome::Error);
+        assert!(
+            result
+                .error_message
+                .as_deref()
+                .is_some_and(|message| message.contains("Retrieval is disabled")),
+            "offline rejection must explain that retrieval is disabled: {:?}",
+            result.error_message
+        );
+    }
+
+    #[test]
+    fn should_allow_in_document_schema_references_offline() {
+        let schema = serde_json::json!({
+            "$defs": { "identifier": { "type": "string" } },
+            "type": "object",
+            "properties": { "id": { "$ref": "#/$defs/identifier" } },
+            "required": ["id"]
+        });
+
+        let result = validate_and_merge(
+            vec![serde_json::json!({"id": "document-1"})],
+            &schema,
+            MergeMode::ObjectMerge,
+        );
+
+        assert_eq!(result.outcome, Outcome::Success);
+
+        let invalid_result = validate_and_merge(vec![serde_json::json!({"id": 42})], &schema, MergeMode::ObjectMerge);
+        assert_eq!(invalid_result.outcome, Outcome::SchemaInvalid);
     }
 }


### PR DESCRIPTION
Compile caller-provided structured extraction schemas with an explicit offline retriever, preventing future feature unification from enabling HTTP or file access. Regression tests activate both resolvers and prove external references fail closed while local references remain enforced.

Fixes #1520