### PR TITLE
refactor(image): group the DPI decision behind a struct in preprocessing

### DIFF
--- a/.alef-toml-merge-provenance.toml
+++ b/.alef-toml-merge-provenance.toml
@@ -2249,11 +2249,6 @@ values = ["function-too-long"]
 
 [[entries]]
 relative_path = "poly.toml"
-key_path = "per-file-ignores.crates/xberg/src/image/preprocessing.rs"
-values = ["too-many-parameters"]
-
-[[entries]]
-relative_path = "poly.toml"
 key_path = "per-file-ignores.crates/xberg/src/keywords/yake/mod.rs"
 values = ["nesting-too-deep"]
 

--- a/alef.toml
+++ b/alef.toml
@@ -1150,7 +1150,6 @@ traineddata = "traineddata"
 "crates/xberg/src/extractors/wordperfect.rs" = ["file-too-long", "function-too-long"]
 "crates/xberg/src/extractors/xml.rs" = ["function-too-long"]
 "crates/xberg/src/heuristics/analyzer.rs" = ["function-too-long"]
-"crates/xberg/src/image/preprocessing.rs" = ["too-many-parameters"]
 "crates/xberg/src/keywords/yake/mod.rs" = ["nesting-too-deep"]
 "crates/xberg/src/keywords/yake/preprocessor.rs" = ["cyclomatic-complexity"]
 "crates/xberg/src/language_detection/mod.rs" = ["file-too-long"]

--- a/crates/xberg/src/image/preprocessing.rs
+++ b/crates/xberg/src/image/preprocessing.rs
@@ -111,37 +111,34 @@ pub(crate) fn normalize_image_dpi_owned(
     );
 
     let scale_factor = f64::from(target_dpi) / current_dpi;
+    let plan = DpiPlan {
+        original_dpi,
+        target_dpi,
+        scale_factor,
+        auto_adjusted,
+        calculated_dpi,
+    };
 
     if !needs_resize(width as u32, height as u32, scale_factor, config) {
-        return Ok(create_skip_result(
-            rgb_data,
-            width,
-            height,
-            original_dpi,
-            config,
-            target_dpi,
-            scale_factor,
-            auto_adjusted,
-            calculated_dpi,
-        ));
+        return Ok(create_skip_result(rgb_data, width, height, config, &plan));
     }
 
     let (new_width, new_height, final_scale, dimension_clamped) =
         calculate_new_dimensions(width as u32, height as u32, scale_factor, config);
 
+    // The resize path records the clamped scale where the skip path records the unclamped one.
+    let plan = DpiPlan {
+        scale_factor: final_scale,
+        ..plan
+    };
+
     match perform_resize(
         &rgb_data,
-        width as u32,
-        height as u32,
-        new_width,
-        new_height,
-        final_scale,
-        original_dpi,
-        target_dpi,
-        auto_adjusted,
+        (width as u32, height as u32),
+        (new_width, new_height),
         dimension_clamped,
-        calculated_dpi,
         config,
+        &plan,
     ) {
         Ok(result) => Ok(result),
         Err(error) => Err((error, rgb_data)),
@@ -162,6 +159,15 @@ pub(crate) fn normalized_image_dimensions(
     }
     let (new_width, new_height, _, _) = calculate_new_dimensions(width, height, scale_factor, config);
     (new_width, new_height)
+}
+
+/// The DPI decision both outcomes of `normalize_image_dpi_owned` record in their metadata.
+struct DpiPlan {
+    original_dpi: (f64, f64),
+    target_dpi: i32,
+    scale_factor: f64,
+    auto_adjusted: bool,
+    calculated_dpi: Option<i32>,
 }
 
 /// Calculate target DPI based on configuration
@@ -226,32 +232,27 @@ fn calculate_new_dimensions(
 }
 
 /// Create result when resize is skipped
-#[allow(clippy::too_many_arguments)]
 fn create_skip_result(
     rgb_data: Vec<u8>,
     width: usize,
     height: usize,
-    original_dpi: (f64, f64),
     config: &ExtractionConfig,
-    target_dpi: i32,
-    scale_factor: f64,
-    auto_adjusted: bool,
-    calculated_dpi: Option<i32>,
+    plan: &DpiPlan,
 ) -> NormalizeResult {
     NormalizeResult {
         rgb_data,
         dimensions: (width, height),
         metadata: ImagePreprocessingMetadata {
             original_dimensions: (width, height).into(),
-            original_dpi: original_dpi.into(),
+            original_dpi: plan.original_dpi.into(),
             target_dpi: config.target_dpi,
-            scale_factor,
-            auto_adjusted,
-            final_dpi: target_dpi,
+            scale_factor: plan.scale_factor,
+            auto_adjusted: plan.auto_adjusted,
+            final_dpi: plan.target_dpi,
             new_dimensions: None,
             resample_method: "NONE".to_string(),
             dimension_clamped: false,
-            calculated_dpi,
+            calculated_dpi: plan.calculated_dpi,
             skipped_resize: true,
             resize_error: None,
         },
@@ -259,21 +260,17 @@ fn create_skip_result(
 }
 
 /// Perform the actual resize operation
-#[allow(clippy::too_many_arguments)]
 fn perform_resize(
     rgb_data: &[u8],
-    original_width: u32,
-    original_height: u32,
-    new_width: u32,
-    new_height: u32,
-    final_scale: f64,
-    original_dpi: (f64, f64),
-    target_dpi: i32,
-    auto_adjusted: bool,
+    original: (u32, u32),
+    new: (u32, u32),
     dimension_clamped: bool,
-    calculated_dpi: Option<i32>,
     config: &ExtractionConfig,
+    plan: &DpiPlan,
 ) -> Result<NormalizeResult> {
+    let (original_width, original_height) = original;
+    let (new_width, new_height) = new;
+    let final_scale = plan.scale_factor;
     let result_rgb_data = resize_rgb(
         rgb_data,
         original_width,
@@ -285,15 +282,15 @@ fn perform_resize(
 
     let metadata = ImagePreprocessingMetadata {
         original_dimensions: (original_width as usize, original_height as usize).into(),
-        original_dpi: original_dpi.into(),
+        original_dpi: plan.original_dpi.into(),
         target_dpi: config.target_dpi,
         scale_factor: final_scale,
-        auto_adjusted,
-        final_dpi: target_dpi,
+        auto_adjusted: plan.auto_adjusted,
+        final_dpi: plan.target_dpi,
         new_dimensions: Some((new_width as usize, new_height as usize).into()),
         resample_method: if final_scale < 1.0 { "LANCZOS3" } else { "CATMULLROM" }.to_string(),
         dimension_clamped,
-        calculated_dpi,
+        calculated_dpi: plan.calculated_dpi,
         skipped_resize: false,
         resize_error: None,
     };


### PR DESCRIPTION
## What

One file paid off the `#1567` baseline: `crates/xberg/src/image/preprocessing.rs`, listed for
`too-many-parameters`.

Two private helpers carried `#[allow(clippy::too_many_arguments)]` and between them took the same
five values describing one decision: the DPI the module settled on, the scale it implies, whether it
was auto-adjusted, and the original DPI it came from. Those five now travel as a `DpiPlan`.

| function | before | after |
|---|---:|---:|
| `create_skip_result` | 9 | 5 |
| `perform_resize` | 12 | 6 |

`perform_resize` also takes its two dimension pairs as tuples rather than four scalars. Both
`#[allow(clippy::too_many_arguments)]` attributes are gone; no function in the file now exceeds six
parameters, so the `alef.toml` entry is deleted.

## Behaviour

Unchanged, and checked rather than asserted. A temporary differential harness ran the same matrix
through `normalize_image_dpi_owned` on `main` and on this branch, **576 cases**: 3 target DPIs x 3
max dimensions x auto-adjust on/off x 2 min/max DPI pairs x 4 image sizes x 4 input DPIs, including
the invalid-input paths. It recorded output dimensions, buffer length, the full
`ImagePreprocessingMetadata` and the error text for every case. The two files are byte-identical.
The harness was removed before committing.

The one subtlety worth naming: the skip path records the unclamped `scale_factor` while the resize
path records the clamped `final_scale` that `calculate_new_dimensions` returns. The plan is rebuilt
with the clamped value on that path, which is why there are two `DpiPlan` bindings rather than one.

## Gates

Run against `e512a9cbe`:

- `cargo test -p xberg --lib --features ocr-pipeline` — 1788 passed, 0 failed
- `cargo clippy -p xberg --features ocr-pipeline --all-targets -- -D warnings` — clean
- `cargo fmt -p xberg -- --check` — clean

`ocr-pipeline` is the feature that gates `pub mod image`, so the default-feature build never compiles
this file.

**`poly lint` was not run locally.** poly panics at startup on `aarch64-apple-darwin`, on both
0.23.1 and 0.24.0, before it reads any file:

```
$ mkdir /tmp/t && cd /tmp/t && printf 'fn main(){}\n' > a.rs && poly lint a.rs
thread 'main' panicked at crates/poly-core/src/engines/astgrep/pack.rs:140:17:
poly's built-in ast-grep pack failed to parse (Fail to parse yaml as RuleConfig)
```

Same with the official release tarballs rather than the Homebrew bottle, in an empty directory with
no `poly.toml`. CI is unaffected, `Validate (poly)` is green on Linux. Flagging it rather than
claiming a green lint I could not produce; the parameter counts above are from parsing the
signatures directly.

## `poly.toml` deliberately not regenerated

`poly.toml` carries the same entry and is generated, so it would normally be refreshed here. It is
not, because `alef diff` reports **the same 467 files would change on a pristine `main` checkout as
with this branch** — an identical list, `poly.toml` among them. The generated tree is already drifted
before this change, which is what the `Alef-generated bindings freshness` job on `main` is failing
on. Regenerating would pull 467 unrelated files into a one-file PR, so `alef.toml` and
`.alef-toml-merge-provenance.toml` are updated at the source and `poly.toml` is left to whoever
clears the drift.

Worth noting the issue says to re-run `alef scaffold`; `poly.toml`'s own header says
`To regenerate: alef generate`. `alef scaffold` updates the provenance file but does not rewrite
`poly.toml`.

## Not covered

Only the `too-many-parameters` entry for this one file. No other baseline entries touched, none
added.

Refs #1567
